### PR TITLE
Fix issues identifying in-repo addon paths in getTelemetryFor.

### DIFF
--- a/transforms/ember-object/test.js
+++ b/transforms/ember-object/test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const { runTransformTest } = require('codemod-cli');
 
 // bootstrap the mock telemetry data
@@ -18,9 +19,7 @@ for (let testFile of testFiles) {
   let moduleName = testFile.replace(/\.[^/.]+$/, '');
   let value = mockTelemetryData[moduleName] || {};
 
-  mockTelemetry[
-    `ember-es6-class-codemod/transforms/ember-object/__testfixtures__/${moduleName}`
-  ] = value;
+  mockTelemetry[path.resolve(__dirname, `./__testfixtures__/${moduleName}`)] = value;
 }
 
 cache.set('telemetry', JSON.stringify(mockTelemetry));

--- a/transforms/helpers/util/get-telemetry-for.js
+++ b/transforms/helpers/util/get-telemetry-for.js
@@ -5,6 +5,7 @@ const cache = require('../../../lib/cache');
 
 const telemetry = cache.has('telemetry') ? JSON.parse(cache.get('telemetry').value) : {};
 const ADDON_PATHS = {};
+const APP_PATHS = {};
 
 let packagePaths = walkSync('./', {
   globs: ['**/package.json'],
@@ -12,9 +13,23 @@ let packagePaths = walkSync('./', {
 });
 
 for (let packagePath of packagePaths) {
-  let { name } = fs.readJsonSync(packagePath);
+  let pkg = fs.readJsonSync(packagePath);
 
-  ADDON_PATHS[path.dirname(path.resolve('.', packagePath))] = name;
+  let packageDir = path.dirname(path.resolve('.', packagePath));
+
+  if (pkg.keywords && pkg.keywords.includes('ember-addon')) {
+    ADDON_PATHS[packageDir] = pkg.name;
+  } else if (isEmberCliProject(pkg)) {
+    APP_PATHS[packageDir] = pkg.name;
+  }
+}
+
+function isEmberCliProject(pkg) {
+  return (
+    pkg &&
+    ((pkg.dependencies && Object.keys(pkg.dependencies).indexOf('ember-cli') !== -1) ||
+      (pkg.devDependencies && Object.keys(pkg.devDependencies).indexOf('ember-cli') !== -1))
+  );
 }
 
 /**
@@ -23,27 +38,63 @@ for (let packagePath of packagePaths) {
  * @param {String} filePath the path on disk (from current working directory)
  * @returns {String} The in-browser module path for the specified filePath
  */
-function getModulePathFor(filePath, addonPaths = ADDON_PATHS) {
-  let fileSegments = filePath.split('/');
-  let addonSegments = [];
+function getModulePathFor(filePath, addonPaths = ADDON_PATHS, appPaths = APP_PATHS) {
+  let bestMatch = '';
+  let moduleNameRoot, relativePath, isApp, result;
 
-  while (fileSegments.length > 0) {
-    addonSegments.push(fileSegments.shift());
-
-    if (addonPaths[addonSegments.join('/')]) {
-      break;
+  for (let addonPath in addonPaths) {
+    if (filePath.startsWith(addonPath) && addonPath.length > bestMatch.length) {
+      bestMatch = addonPath;
+      moduleNameRoot = addonPaths[addonPath];
+      relativePath = filePath.slice(
+        addonPath.length + 1 /* for slash */,
+        -path.extname(filePath).length
+      );
     }
   }
 
-  let addonFilePath = addonSegments.join('/');
-  let addonName = addonPaths[addonFilePath];
+  for (let appPath in appPaths) {
+    if (filePath.startsWith(appPath) && appPath.length > bestMatch.length) {
+      bestMatch = appPath;
+      moduleNameRoot = appPaths[appPath];
+      relativePath = filePath.slice(
+        appPath.length + 1 /* for slash */,
+        -path.extname(filePath).length
+      );
+      isApp = true;
+    }
+  }
 
-  let relativeFilePath = fileSegments
-    .join('/')
-    .replace(/^(addon|app)\//, '')
-    .replace(/\.[^/.]+$/, '');
+  if (!relativePath && process.cwd() === path.resolve(__dirname, '../../..')) {
+    // this is pretty odd, but our tests in
+    // transforms/ember-object/__testfixtures__ don't actually live in an ember
+    // app or addon, so the standard logic above doesn't work for them
+    //
+    // this works by passing through the input file name when we are operating
+    // on the local ember-es6-class-codemod repo **and** we were not able to
+    // resolve a relativePath via normal means
+    return filePath.replace(/\.[^/.]+$/, '');
+  }
 
-  return `${addonName}/${relativeFilePath}`;
+  if (!relativePath) {
+    return;
+  }
+
+  if (isApp) {
+    if (relativePath.startsWith('app')) {
+      result = `${moduleNameRoot}${relativePath.slice(3)}`;
+    } else if (relativePath.startsWith('tests')) {
+      result = `${moduleNameRoot}/${relativePath}`;
+    }
+  } else {
+    if (relativePath.startsWith('addon-test-support')) {
+      result = `${moduleNameRoot}/test-support${relativePath.slice(18)}`;
+    } else if (relativePath.startsWith('addon')) {
+      result = `${moduleNameRoot}${relativePath.slice(5)}`;
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -54,8 +105,9 @@ function getModulePathFor(filePath, addonPaths = ADDON_PATHS) {
  */
 function getTelemetryFor(filePath) {
   let modulePath = getModulePathFor(filePath);
+  let data = telemetry[modulePath];
 
-  return telemetry[modulePath];
+  return data;
 }
 
 module.exports = {

--- a/transforms/helpers/util/get-telemetry-for.test.js
+++ b/transforms/helpers/util/get-telemetry-for.test.js
@@ -1,16 +1,57 @@
 const { getModulePathFor } = require('./get-telemetry-for');
 
 describe('getModulePathFor', () => {
-  test('accesses telemetry data for the specified app module', () => {
-    const addonPaths = {
-      '/User/whomever/voyager-web/lib/invitation-platform': 'invitation-platform',
-    };
+  const addonPaths = {
+    '/User/whomever/some-app/lib/special-sauce': 'special-sauce',
+  };
+
+  const appPaths = {
+    '/User/whomever/some-app': 'some-app',
+  };
+
+  test('can determine the runtime module id for a specific on disk in-repo addon file', () => {
+    expect(
+      getModulePathFor(
+        '/User/whomever/some-app/lib/special-sauce/addon/components/fire-sauce.js',
+        addonPaths,
+        appPaths
+      )
+    ).toEqual('special-sauce/components/fire-sauce');
 
     expect(
       getModulePathFor(
-        '/User/whomever/voyager-web/lib/invitation-platform/addon/components/fuse-limit-alert',
-        addonPaths
+        '/User/whomever/some-app/lib/special-sauce/addon-test-support/services/whatever.js',
+        addonPaths,
+        appPaths
       )
-    ).toEqual('invitation-platform/components/fuse-limit-alert');
+    ).toEqual('special-sauce/test-support/services/whatever');
+  });
+
+  test("does not process files in an in-repo addon's app/ folder", () => {
+    expect(
+      getModulePathFor(
+        '/User/whomever/some-app/lib/special-sauce/app/services/whatever.js',
+        addonPaths,
+        appPaths
+      )
+    ).toEqual(undefined);
+  });
+
+  test('can determine the runtime module id for a file in the app itself', () => {
+    expect(
+      getModulePathFor(
+        '/User/whomever/some-app/app/services/something-here.js',
+        addonPaths,
+        appPaths
+      )
+    ).toEqual('some-app/services/something-here');
+
+    expect(
+      getModulePathFor(
+        '/User/whomever/some-app/tests/mocks/something-here.js',
+        addonPaths,
+        appPaths
+      )
+    ).toEqual('some-app/tests/mocks/something-here');
   });
 });


### PR DESCRIPTION
With these changes `getModulePathFor` is much more context aware:

* when inside an in-repo addon we support transforming `addon` and `addon-test-support`
* when inside an app we support trransforming `app` and `test`