### PR TITLE
Ensure logging of modules that failed to gather telemetry.

### DIFF
--- a/lib/gather-telemetry.js
+++ b/lib/gather-telemetry.js
@@ -7,6 +7,10 @@ module.exports = async function gatherTelemetry(url) {
 
   await page.goto(url);
 
+  await page.exposeFunction("logErrorInNodeProcess", message => {
+    console.error(message); // eslint-disable-line no-console
+  });
+
   // Get the "viewport" of the page, as reported by the page.
   const telemetry = await page.evaluate(() => {
     const SKIPPED_MODULES = ["fetch/ajax"];
@@ -31,7 +35,9 @@ module.exports = async function gatherTelemetry(url) {
         }
       } catch (error) {
         // log the error, but continue
-        console.error(`error evaluating \`${modulePath}\`: ${error.message}`); // eslint-disable-line no-console
+        window.logErrorInNodeProcess(
+          `error evaluating \`${modulePath}\`: ${error.message}`
+        );
       }
     }
 


### PR DESCRIPTION
Calling `console.error` from within the `page.evaluate` callback logs the error to puppeteer instances console not the console that is actually running the codemod process.

This fixes that issue (so the messages actually bubble up now) by using `page.exposeFunction` which **does** have access to the current node process.