### PR TITLE
Fix in-repo addon acceptance test to demonstrate real world failure with in-repo addons.

### DIFF
--- a/test/fixtures/input/lib/special-sauce/package.json
+++ b/test/fixtures/input/lib/special-sauce/package.json
@@ -4,6 +4,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "ember-cli-babel": "*",
     "ember-cli-htmlbars": "*"
   }
 }

--- a/test/fixtures/output/lib/special-sauce/package.json
+++ b/test/fixtures/output/lib/special-sauce/package.json
@@ -4,6 +4,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "ember-cli-babel": "*",
     "ember-cli-htmlbars": "*"
   }
 }

--- a/test/run-test.js
+++ b/test/run-test.js
@@ -30,7 +30,14 @@ const execOpts = { cwd: inputDir, stderr: 'inherit' };
 
   console.log('running codemod');
 
-  await execa('../../../bin/cli.js', ['http://localhost:4200', 'app'], execOpts);
+  const codemodProcess = execa(
+    '../../../bin/cli.js',
+    ['http://localhost:4200', 'app', 'lib/special-sauce/addon'],
+    execOpts
+  );
+  codemodProcess.stdout.pipe(process.stdout);
+
+  await codemodProcess;
 
   console.log('codemod complete, ending serve');
 

--- a/test/run-test.js
+++ b/test/run-test.js
@@ -47,6 +47,7 @@ const execOpts = { cwd: inputDir, stderr: 'inherit' };
 
   try {
     await execa('diff', ['-rq', './app', '../output/app'], execOpts);
+    await execa('diff', ['-rq', './lib', '../output/lib'], execOpts);
   } catch (e) {
     console.error('codemod did not run successfully');
     console.log(e.stdout);


### PR DESCRIPTION
The changes in
https://github.com/ember-codemods/ember-es6-class-codemod/pull/128 passed CI because I had forgotten to add an assertion on the new in-repo addon path. 🤦

At the moment, this test will fail (which is honestly what I expected when I submitted #128 based on reports from folks actively testing the codemod) until #129 is merged and this is rebased.