### PR TITLE
[REFACTOR] Convert to single quote

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,7 @@
-"use strict";
+'use strict';
 
 module.exports = {
-  singleQuote: false,
-  trailingComma: "none"
+  singleQuote: true,
+  trailingComma: 'es5',
+  printWidth: 100,
 };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-"use strict";
+'use strict';
 
-const gatherTelemetry = require("../lib/gather-telemetry");
+const gatherTelemetry = require('../lib/gather-telemetry');
 
 (async () => {
   await gatherTelemetry(process.argv[2]);
 
-  require("codemod-cli").runTransform(
+  require('codemod-cli').runTransform(
     __dirname,
-    "ember-object",
+    'ember-object',
     process.argv.slice(2) /* paths or globs */
   );
 })();

--- a/bin/temeletry.js
+++ b/bin/temeletry.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-"use strict";
+'use strict';
 
-const gatherTelemetry = require("../lib/gather-telemetry");
+const gatherTelemetry = require('../lib/gather-telemetry');
 
 gatherTelemetry(process.argv[2]);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,5 +1,5 @@
-const Cache = require("sync-disk-cache");
-const getRepoInfo = require("git-repo-info");
+const Cache = require('sync-disk-cache');
+const getRepoInfo = require('git-repo-info');
 
 const gitInfo = getRepoInfo();
 const cache = new Cache(`native-class-codemod-${gitInfo.sha}-${process.cwd()}`);

--- a/lib/gather-telemetry.js
+++ b/lib/gather-telemetry.js
@@ -1,5 +1,5 @@
-const puppeteer = require("puppeteer");
-const cache = require("./cache");
+const puppeteer = require('puppeteer');
+const cache = require('./cache');
 
 module.exports = async function gatherTelemetry(url) {
   const browser = await puppeteer.launch({ ignoreHTTPSErrors: true });
@@ -7,13 +7,13 @@ module.exports = async function gatherTelemetry(url) {
 
   await page.goto(url);
 
-  await page.exposeFunction("logErrorInNodeProcess", message => {
+  await page.exposeFunction('logErrorInNodeProcess', message => {
     console.error(message); // eslint-disable-line no-console
   });
 
   // Get the "viewport" of the page, as reported by the page.
   const telemetry = await page.evaluate(() => {
-    const SKIPPED_MODULES = ["fetch/ajax"];
+    const SKIPPED_MODULES = ['fetch/ajax'];
 
     /* globals window, Ember */
     let telemetry = {};
@@ -35,9 +35,7 @@ module.exports = async function gatherTelemetry(url) {
         }
       } catch (error) {
         // log the error, but continue
-        window.logErrorInNodeProcess(
-          `error evaluating \`${modulePath}\`: ${error.message}`
-        );
+        window.logErrorInNodeProcess(`error evaluating \`${modulePath}\`: ${error.message}`);
       }
     }
 
@@ -49,18 +47,15 @@ module.exports = async function gatherTelemetry(url) {
      */
     function getType(object) {
       const types = [
-        "Application",
-        "Controller",
-        "Route",
-        "Component",
-        "Service",
-        "Router",
-        "Engine"
+        'Application',
+        'Controller',
+        'Route',
+        'Component',
+        'Service',
+        'Router',
+        'Engine',
       ];
-      return (
-        types.find(type => Ember[type] && object instanceof Ember[type]) ||
-        "EmberObject"
-      );
+      return types.find(type => Ember[type] && object instanceof Ember[type]) || 'EmberObject';
     }
 
     /**
@@ -85,32 +80,24 @@ module.exports = async function gatherTelemetry(url) {
       const { source } = meta;
       const type = getType(source);
 
-      const ownProperties = Object.keys(source).filter(
-        key => !["_super", "actions"].includes(key)
-      );
+      const ownProperties = Object.keys(source).filter(key => !['_super', 'actions'].includes(key));
 
       const ownActions = source.actions ? Object.keys(source.actions) : [];
 
       const observedProperties = Object.keys(meta._watching || {});
 
-      const overriddenProperties = ownProperties.filter(key =>
-        isOverridden(meta.parent, key)
-      );
+      const overriddenProperties = ownProperties.filter(key => isOverridden(meta.parent, key));
 
-      const overriddenActions = ownActions.filter(key =>
-        isActionOverridden(meta.parent, key)
-      );
+      const overriddenActions = ownActions.filter(key => isActionOverridden(meta.parent, key));
 
       const computedProperties = [];
       meta.forEachDescriptors((name, desc) => {
         const descProto = Object.getPrototypeOf(desc) || {};
-        const constructorName = descProto.constructor
-          ? descProto.constructor.name
-          : "";
+        const constructorName = descProto.constructor ? descProto.constructor.name : '';
         if (
           desc.enumerable &&
           ownProperties.includes(name) &&
-          constructorName === "ComputedProperty"
+          constructorName === 'ComputedProperty'
         ) {
           computedProperties.push(name);
         }
@@ -119,16 +106,16 @@ module.exports = async function gatherTelemetry(url) {
       const { offProperties, unobservedProperties } = ownProperties.reduce(
         ({ offProperties, unobservedProperties }, key) => {
           const { type, events } = getListenerData(meta.parent, key);
-          if (type === "event") {
+          if (type === 'event') {
             offProperties[key] = events;
-          } else if (type === "observer") {
+          } else if (type === 'observer') {
             unobservedProperties[key] = events;
           }
           return { offProperties, unobservedProperties };
         },
         {
           offProperties: {},
-          unobservedProperties: {}
+          unobservedProperties: {},
         }
       );
 
@@ -147,7 +134,7 @@ module.exports = async function gatherTelemetry(url) {
         overriddenProperties,
         ownProperties,
         type,
-        unobservedProperties
+        unobservedProperties,
       };
     }
 
@@ -162,24 +149,21 @@ module.exports = async function gatherTelemetry(url) {
      */
     function getListenerData(map, key) {
       while (map) {
-        let type = "event";
-        const events = parseListeners(map._listeners).reduce(
-          (acc, [event, , method]) => {
-            if (method === key) {
-              const [observedProp, observerEvent] = event.split(":");
-              if (observerEvent) {
-                type = "observer";
-              }
-              acc.push(observedProp);
+        let type = 'event';
+        const events = parseListeners(map._listeners).reduce((acc, [event, , method]) => {
+          if (method === key) {
+            const [observedProp, observerEvent] = event.split(':');
+            if (observerEvent) {
+              type = 'observer';
             }
-            return acc;
-          },
-          []
-        );
+            acc.push(observedProp);
+          }
+          return acc;
+        }, []);
         if (events.length) {
           return {
             type,
-            events
+            events,
           };
         }
         map = map.parent;
@@ -197,12 +181,12 @@ module.exports = async function gatherTelemetry(url) {
     function parseListeners(listeners = [], size = 4) {
       var result = [];
       if (listeners.length) {
-        if (typeof listeners[0] === "object") {
+        if (typeof listeners[0] === 'object') {
           result = listeners.map(({ event, target, method, kind }) => [
             event,
             target,
             method,
-            kind
+            kind,
           ]);
         } else {
           const input = listeners.slice(0);
@@ -257,7 +241,7 @@ module.exports = async function gatherTelemetry(url) {
     return telemetry;
   });
 
-  cache.set("telemetry", JSON.stringify(telemetry));
+  cache.set('telemetry', JSON.stringify(telemetry));
 
   await browser.close();
 };

--- a/test/fixtures/input/app/app.js
+++ b/test/fixtures/input/app/app.js
@@ -6,7 +6,7 @@ import config from './config/environment';
 const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver
+  Resolver,
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/test/fixtures/input/app/components/test-component.js
+++ b/test/fixtures/input/app/components/test-component.js
@@ -1,12 +1,12 @@
-import Component from "@ember/component";
-import { computed } from "@ember/object";
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 function fullNameMacro() {
-  return computed("firstName", "lastName", function() {
+  return computed('firstName', 'lastName', function() {
     return `${this.firstName} ${this.lastName}`;
   });
 }
 
 export default Component.extend({
-  fullName: fullNameMacro()
+  fullName: fullNameMacro(),
 });

--- a/test/fixtures/input/app/router.js
+++ b/test/fixtures/input/app/router.js
@@ -3,10 +3,9 @@ import config from './config/environment';
 
 const Router = EmberRouter.extend({
   location: config.locationType,
-  rootURL: config.rootURL
+  rootURL: config.rootURL,
 });
 
-Router.map(function() {
-});
+Router.map(function() {});
 
 export default Router;

--- a/test/fixtures/output/app/app.js
+++ b/test/fixtures/output/app/app.js
@@ -1,4 +1,4 @@
-import classic from "ember-classic-decorator";
+import classic from 'ember-classic-decorator';
 import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';

--- a/test/fixtures/output/app/components/test-component.js
+++ b/test/fixtures/output/app/components/test-component.js
@@ -1,9 +1,9 @@
-import classic from "ember-classic-decorator";
-import { computed } from "@ember/object";
-import Component from "@ember/component";
+import classic from 'ember-classic-decorator';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 
 function fullNameMacro() {
-  return computed("firstName", "lastName", function() {
+  return computed('firstName', 'lastName', function() {
     return `${this.firstName} ${this.lastName}`;
   });
 }

--- a/test/fixtures/output/app/router.js
+++ b/test/fixtures/output/app/router.js
@@ -1,4 +1,4 @@
-import classic from "ember-classic-decorator";
+import classic from 'ember-classic-decorator';
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
@@ -8,7 +8,6 @@ class RouterRouter extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-RouterRouter.map(function() {
-});
+RouterRouter.map(function() {});
 
 export default RouterRouter;

--- a/test/fixtures/output/lib/special-sauce/addon/components/fire-sauce.js
+++ b/test/fixtures/output/lib/special-sauce/addon/components/fire-sauce.js
@@ -1,5 +1,5 @@
-import classic from "ember-classic-decorator";
-import Component from "@ember/component";
+import classic from 'ember-classic-decorator';
+import Component from '@ember/component';
 
 @classic
 export default class FireSauceComponent extends Component {}

--- a/test/run-test.js
+++ b/test/run-test.js
@@ -1,56 +1,52 @@
 /* eslint-disable no-console */
 
-const { spawn } = require("child_process");
-const execa = require("execa");
-const path = require("path");
+const { spawn } = require('child_process');
+const execa = require('execa');
+const path = require('path');
 
 // resolved from the root of the project
-const inputDir = path.resolve("./test/fixtures/input");
-const execOpts = { cwd: inputDir, stderr: "inherit" };
+const inputDir = path.resolve('./test/fixtures/input');
+const execOpts = { cwd: inputDir, stderr: 'inherit' };
 
 (async () => {
-  console.log("installing deps");
+  console.log('installing deps');
 
-  await execa("rm", ["-rf", "node_modules"], execOpts);
-  await execa("yarn", ["install"], execOpts);
+  await execa('rm', ['-rf', 'node_modules'], execOpts);
+  await execa('yarn', ['install'], execOpts);
 
-  console.log("starting serve");
+  console.log('starting serve');
 
   // We use spawn for this one so we can kill it later without throwing an error
-  const emberServe = spawn("yarn", ["start"], execOpts);
+  const emberServe = spawn('yarn', ['start'], execOpts);
   emberServe.stderr.pipe(process.stderr);
 
   await new Promise(resolve => {
-    emberServe.stdout.on("data", data => {
-      if (data.toString().includes("Build successful")) {
+    emberServe.stdout.on('data', data => {
+      if (data.toString().includes('Build successful')) {
         resolve();
       }
     });
   });
 
-  console.log("running codemod");
+  console.log('running codemod');
 
-  await execa(
-    "../../../bin/cli.js",
-    ["http://localhost:4200", "app"],
-    execOpts
-  );
+  await execa('../../../bin/cli.js', ['http://localhost:4200', 'app'], execOpts);
 
-  console.log("codemod complete, ending serve");
+  console.log('codemod complete, ending serve');
 
-  emberServe.kill("SIGTERM");
+  emberServe.kill('SIGTERM');
 
-  console.log("comparing results");
+  console.log('comparing results');
 
   try {
-    await execa("diff", ["-rq", "./app", "../output/app"], execOpts);
+    await execa('diff', ['-rq', './app', '../output/app'], execOpts);
   } catch (e) {
-    console.error("codemod did not run successfully");
+    console.error('codemod did not run successfully');
     console.log(e.stdout);
 
     process.exit(1);
   }
 
-  console.log("codemod ran successfully! 🎉");
+  console.log('codemod ran successfully! 🎉');
   process.exit(0);
 })();

--- a/transforms/ember-object/__testfixtures__/action-invalid.input.js
+++ b/transforms/ember-object/__testfixtures__/action-invalid.input.js
@@ -2,36 +2,36 @@ const Foo = EmberObject.extend({
   actions: {
     bar() {
       this._super(...arguments);
-      this.get("bar")();
-    }
-  }
+      this.get('bar')();
+    },
+  },
 });
 
 const Foo = EmberObject.extend({
   actions: {
     biz() {
       this._super(...arguments);
-      get(this, "biz")();
-    }
-  }
+      get(this, 'biz')();
+    },
+  },
 });
 
 const Foo = EmberObject.extend({
   actions: {
     baz() {
       this._super(...arguments);
-      tryInvoke(this, "baz");
-    }
-  }
+      tryInvoke(this, 'baz');
+    },
+  },
 });
 
 const Foo = EmberObject.extend({
   actions: {
     sendBaz() {
       this._super(...arguments);
-      this.send("sendBaz");
-    }
-  }
+      this.send('sendBaz');
+    },
+  },
 });
 
 const Foo = EmberObject.extend({
@@ -39,6 +39,6 @@ const Foo = EmberObject.extend({
     thisBaz() {
       this._super(...arguments);
       this.thisBaz();
-    }
-  }
+    },
+  },
 });

--- a/transforms/ember-object/__testfixtures__/action-invalid.output.js
+++ b/transforms/ember-object/__testfixtures__/action-invalid.output.js
@@ -2,36 +2,36 @@ const Foo = EmberObject.extend({
   actions: {
     bar() {
       this._super(...arguments);
-      this.get("bar")();
-    }
-  }
+      this.get('bar')();
+    },
+  },
 });
 
 const Foo = EmberObject.extend({
   actions: {
     biz() {
       this._super(...arguments);
-      get(this, "biz")();
-    }
-  }
+      get(this, 'biz')();
+    },
+  },
 });
 
 const Foo = EmberObject.extend({
   actions: {
     baz() {
       this._super(...arguments);
-      tryInvoke(this, "baz");
-    }
-  }
+      tryInvoke(this, 'baz');
+    },
+  },
 });
 
 const Foo = EmberObject.extend({
   actions: {
     sendBaz() {
       this._super(...arguments);
-      this.send("sendBaz");
-    }
-  }
+      this.send('sendBaz');
+    },
+  },
 });
 
 const Foo = EmberObject.extend({
@@ -39,6 +39,6 @@ const Foo = EmberObject.extend({
     thisBaz() {
       this._super(...arguments);
       this.thisBaz();
-    }
-  }
+    },
+  },
 });

--- a/transforms/ember-object/__testfixtures__/basic.input.js
+++ b/transforms/ember-object/__testfixtures__/basic.input.js
@@ -5,10 +5,10 @@ const Foo = Test.extend(MyMixin, {
   /**
    * Property comments
    */
-  prop: "defaultValue",
+  prop: 'defaultValue',
   boolProp: true,
   numProp: 123,
-  [MY_VAL]: "val",
+  [MY_VAL]: 'val',
   queryParams: {},
   someVal,
 
@@ -31,7 +31,7 @@ const Foo = Test.extend(MyMixin, {
 
   anotherMethod() {
     this._super(...arguments);
-  }
+  },
 });
 
 const Foo = EmberObject.extend(MixinA, MixinB);

--- a/transforms/ember-object/__testfixtures__/basic.output.js
+++ b/transforms/ember-object/__testfixtures__/basic.output.js
@@ -1,4 +1,4 @@
-import classic from "ember-classic-decorator";
+import classic from 'ember-classic-decorator';
 
 /**
  * Program comments
@@ -8,11 +8,11 @@ class Foo extends Test.extend(MyMixin) {
   /**
    * Property comments
    */
-  prop = "defaultValue";
+  prop = 'defaultValue';
 
   boolProp = true;
   numProp = 123;
-  [MY_VAL] = "val";
+  [MY_VAL] = 'val';
   queryParams = {};
   someVal = someVal;
 

--- a/transforms/ember-object/__testfixtures__/class-fields.input.js
+++ b/transforms/ember-object/__testfixtures__/class-fields.input.js
@@ -21,5 +21,5 @@ const Foo = Test.extend({
 
   anotherMethod() {
     this._super(...arguments);
-  }
+  },
 });

--- a/transforms/ember-object/__testfixtures__/class-fields.output.js
+++ b/transforms/ember-object/__testfixtures__/class-fields.output.js
@@ -1,4 +1,4 @@
-import classic from "ember-classic-decorator";
+import classic from 'ember-classic-decorator';
 
 /**
  * Program comments

--- a/transforms/ember-object/__testfixtures__/decorators-invalid.input.js
+++ b/transforms/ember-object/__testfixtures__/decorators-invalid.input.js
@@ -1,52 +1,52 @@
 // Do not transform
 const Foo = EmberObject.extend({
   statefulObject: {},
-  statefulArray: []
+  statefulArray: [],
 });
 
 // Do not transform if not a primitive value
 const Foo = EmberObject.extend({
-  macroValue: macro()
+  macroValue: macro(),
 });
 
 // Do not transform as a computed property has readOnly and volatile with meta
 const Foo = EmberObject.extend({
-  firstName: "",
-  lastName: "",
+  firstName: '',
+  lastName: '',
 
-  fName2: computed("firstName", "lastName", function() {
+  fName2: computed('firstName', 'lastName', function() {
     return true;
   })
-    .property("baz")
+    .property('baz')
     .readOnly()
     .volatile()
-    .meta({ type: "Property" })
+    .meta({ type: 'Property' }),
 });
 
 // Do not transform as a computed meta has volatile
 const Foo = EmberObject.extend({
-  lName1: add("description", "lastName").volatile()
+  lName1: add('description', 'lastName').volatile(),
 });
 
 // Do not transform as computed prop has `property`
 const Foo = EmberObject.extend({
-  fName2: computed("firstName", "lastName", function() {
+  fName2: computed('firstName', 'lastName', function() {
     return true;
-  }).property("baz")
+  }).property('baz'),
 });
 
 // Do not transform as computed prop has `meta`
 const Foo = EmberObject.extend({
-  fName2: computed("firstName", "lastName", function() {
+  fName2: computed('firstName', 'lastName', function() {
     return true;
-  }).meta({ type: "Property" })
+  }).meta({ type: 'Property' }),
 });
 
 // Do not transform as action name matches lifecycle hook
 const Foo = EmberObject.extend({
   actions: {
     click() {
-      this.set("clicked", true);
-    }
-  }
+      this.set('clicked', true);
+    },
+  },
 });

--- a/transforms/ember-object/__testfixtures__/decorators-invalid.output.js
+++ b/transforms/ember-object/__testfixtures__/decorators-invalid.output.js
@@ -1,52 +1,52 @@
 // Do not transform
 const Foo = EmberObject.extend({
   statefulObject: {},
-  statefulArray: []
+  statefulArray: [],
 });
 
 // Do not transform if not a primitive value
 const Foo = EmberObject.extend({
-  macroValue: macro()
+  macroValue: macro(),
 });
 
 // Do not transform as a computed property has readOnly and volatile with meta
 const Foo = EmberObject.extend({
-  firstName: "",
-  lastName: "",
+  firstName: '',
+  lastName: '',
 
-  fName2: computed("firstName", "lastName", function() {
+  fName2: computed('firstName', 'lastName', function() {
     return true;
   })
-    .property("baz")
+    .property('baz')
     .readOnly()
     .volatile()
-    .meta({ type: "Property" })
+    .meta({ type: 'Property' }),
 });
 
 // Do not transform as a computed meta has volatile
 const Foo = EmberObject.extend({
-  lName1: add("description", "lastName").volatile()
+  lName1: add('description', 'lastName').volatile(),
 });
 
 // Do not transform as computed prop has `property`
 const Foo = EmberObject.extend({
-  fName2: computed("firstName", "lastName", function() {
+  fName2: computed('firstName', 'lastName', function() {
     return true;
-  }).property("baz")
+  }).property('baz'),
 });
 
 // Do not transform as computed prop has `meta`
 const Foo = EmberObject.extend({
-  fName2: computed("firstName", "lastName", function() {
+  fName2: computed('firstName', 'lastName', function() {
     return true;
-  }).meta({ type: "Property" })
+  }).meta({ type: 'Property' }),
 });
 
 // Do not transform as action name matches lifecycle hook
 const Foo = EmberObject.extend({
   actions: {
     click() {
-      this.set("clicked", true);
-    }
-  }
+      this.set('clicked', true);
+    },
+  },
 });

--- a/transforms/ember-object/__testfixtures__/decorators.input.js
+++ b/transforms/ember-object/__testfixtures__/decorators.input.js
@@ -7,32 +7,32 @@ import {
   oneWay as enoWay,
   sum as add,
   map as computedMap,
-  filter
-} from "@ember/object/computed";
-import { get, set, observer as watcher, computed } from "@ember/object";
-import { inject as controller } from "@ember/controller";
-import { inject as service } from "@ember/service";
-import { on } from "@ember/object/evented";
-import layout from "components/templates/foo";
-import { someActionUtil } from "some/action/util";
-import NUMERIC_CONSTANT from "constants/numbers";
+  filter,
+} from '@ember/object/computed';
+import { get, set, observer as watcher, computed } from '@ember/object';
+import { inject as controller } from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { on } from '@ember/object/evented';
+import layout from 'components/templates/foo';
+import { someActionUtil } from 'some/action/util';
+import NUMERIC_CONSTANT from 'constants/numbers';
 
 const Foo = EmberObject.extend({
-  tagName: "div",
-  classNames: ["test-class", "custom-class"],
-  a: "",
-  b: service("store"),
-  myController: controller("abc"),
-  observedProp: watcher("xyz", function() {
-    return "observed";
+  tagName: 'div',
+  classNames: ['test-class', 'custom-class'],
+  a: '',
+  b: service('store'),
+  myController: controller('abc'),
+  observedProp: watcher('xyz', function() {
+    return 'observed';
   }),
-  event: on("click", function() {
-    return "abc";
+  event: on('click', function() {
+    return 'abc';
   }),
-  excitingChores: computedMap("chores", function(chore, index) {
-    return chore.toUpperCase() + "!";
+  excitingChores: computedMap('chores', function(chore, index) {
+    return chore.toUpperCase() + '!';
   }),
-  remainingChores: filter("chores", function(chore, index, array) {
+  remainingChores: filter('chores', function(chore, index, array) {
     return !chore.done;
   }),
 
@@ -45,20 +45,20 @@ const Foo = EmberObject.extend({
     baz() {
       this._super(...arguments);
     },
-    biz() {}
-  }
+    biz() {},
+  },
 });
 
 var comp = EmberObject.extend({
-  classNameBindings: ["isEnabled:enabled:disabled", "a:b:c", "c:d"],
-  isEnabled: computed("a", "c", function() {
+  classNameBindings: ['isEnabled:enabled:disabled', 'a:b:c', 'c:d'],
+  isEnabled: computed('a', 'c', function() {
     return false;
   }),
   a: true,
-  c: "",
-  attributeBindings: ["customHref:href"],
+  c: '',
+  attributeBindings: ['customHref:href'],
 
-  customHref: "http://emberjs.com"
+  customHref: 'http://emberjs.com',
 });
 
 const Foo = EmberObject.extend({
@@ -68,31 +68,26 @@ const Foo = EmberObject.extend({
   /**
   Computed fullname
   */
-  fullName: computed("firstName", "lastName", {
+  fullName: computed('firstName', 'lastName', {
     get(key) {
-      return (
-        this._super(...arguments) &&
-        `${this.get("firstName")} ${this.get("lastName")}`
-      );
+      return this._super(...arguments) && `${this.get('firstName')} ${this.get('lastName')}`;
     },
     set(key, value) {
       let [firstName, lastName] = value.split(/\s+/);
-      this.set("firstName", firstName);
-      this.set("lastName", lastName);
+      this.set('firstName', firstName);
+      this.set('lastName', lastName);
       return value;
-    }
+    },
   }).readOnly(),
   /**
   Computed description
   */
-  description: computed("fullName", "age", "country", function() {
+  description: computed('fullName', 'age', 'country', function() {
     const desc = this._super(...arguments);
     if (desc) {
       return desc;
     }
-    return `${this.get(
-      "fullName"
-    )}; Age: ${this.get("age")}; Country: ${this.get("country")}`;
+    return `${this.get('fullName')}; Age: ${this.get('age')}; Country: ${this.get('country')}`;
   })
     .volatile()
     .readOnly(),
@@ -100,62 +95,62 @@ const Foo = EmberObject.extend({
   /**
    * Fname
    */
-  fName: alias("firstName"),
+  fName: alias('firstName'),
 
   /**
    * Fname1
    */
-  fName1: alias("firstName"),
+  fName1: alias('firstName'),
 
   /**
    * Fname2
    */
-  fName2: computed("firstName", "lastName", function() {
+  fName2: computed('firstName', 'lastName', function() {
     return true;
   }).readOnly(),
 
   /**
    * Fname3
    */
-  fName3: computed("firstName", "lastName", function() {
+  fName3: computed('firstName', 'lastName', function() {
     return true;
   }).volatile(),
 
   /**
    * Lname
    */
-  lName: alias("firstName", "lastName").readOnly(),
+  lName: alias('firstName', 'lastName').readOnly(),
 
   /**
    * Lname1
    */
-  lName1: add("description", "lastName"),
+  lName1: add('description', 'lastName'),
 
   /**
    * Lname2
    */
-  lName2: readOnly("description"),
+  lName2: readOnly('description'),
 
   /**
    * Lname3
    */
-  lName3: reads("description", "lastName"),
+  lName3: reads('description', 'lastName'),
 
   /**
    * Lname4
    */
-  lName4: enoWay("description", "lastName"),
+  lName4: enoWay('description', 'lastName'),
 
   /**
    * Lname5
    */
-  lName5: add("description", "lastName").readOnly(),
+  lName5: add('description', 'lastName').readOnly(),
 
-  isEqualToLimit: equal("limit", NUMERIC_CONSTANT.LIMIT).readOnly(),
+  isEqualToLimit: equal('limit', NUMERIC_CONSTANT.LIMIT).readOnly(),
 
-  isGreaterThanLimit: gt("limit", NUMERIC_CONSTANT).readOnly()
+  isGreaterThanLimit: gt('limit', NUMERIC_CONSTANT).readOnly(),
 });
 
 const Foo = EmberObject.extend({
-  layout
+  layout,
 });

--- a/transforms/ember-object/__testfixtures__/decorators.output.js
+++ b/transforms/ember-object/__testfixtures__/decorators.output.js
@@ -1,8 +1,8 @@
-import classic from "ember-classic-decorator";
-import { attribute, className, classNames, tagName, layout as templateLayout } from "@ember-decorators/component";
-import { observes as watcher, on } from "@ember-decorators/object";
-import { inject as controller } from "@ember/controller";
-import { inject as service } from "@ember/service";
+import classic from 'ember-classic-decorator';
+import { attribute, className, classNames, tagName, layout as templateLayout } from '@ember-decorators/component';
+import { observes as watcher, on } from '@ember-decorators/object';
+import { inject as controller } from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 import {
   filter,
@@ -14,41 +14,41 @@ import {
   equal,
   gt,
   alias,
-} from "@ember/object/computed";
+} from '@ember/object/computed';
 
-import { get, set, action, computed } from "@ember/object";
-import layout from "components/templates/foo";
-import { someActionUtil } from "some/action/util";
-import NUMERIC_CONSTANT from "constants/numbers";
+import { get, set, action, computed } from '@ember/object';
+import layout from 'components/templates/foo';
+import { someActionUtil } from 'some/action/util';
+import NUMERIC_CONSTANT from 'constants/numbers';
 
 @classic
-@tagName("div")
-@classNames("test-class", "custom-class")
+@tagName('div')
+@classNames('test-class', 'custom-class')
 class Foo extends EmberObject {
-  a = "";
+  a = '';
 
-  @service("store")
+  @service('store')
   b;
 
-  @controller("abc")
+  @controller('abc')
   myController;
 
-  @watcher("xyz")
+  @watcher('xyz')
   observedProp() {
-    return "observed";
+    return 'observed';
   }
 
-  @on("click")
+  @on('click')
   event() {
-    return "abc";
+    return 'abc';
   }
 
-  @computedMap("chores", function(chore, index) {
-    return chore.toUpperCase() + "!";
+  @computedMap('chores', function(chore, index) {
+    return chore.toUpperCase() + '!';
   })
   excitingChores;
 
-  @filter("chores", function(chore, index, array) {
+  @filter('chores', function(chore, index, array) {
     return !chore.done;
   })
   remainingChores;
@@ -81,20 +81,20 @@ class Foo extends EmberObject {
 
 @classic
 class Comp extends EmberObject {
-  @computed("a", "c")
-  @className("enabled", "disabled")
+  @computed('a', 'c')
+  @className('enabled', 'disabled')
   get isEnabled() {
     return false;
   }
 
-  @className("b", "c")
+  @className('b', 'c')
   a = true;
 
-  @className("d")
-  c = "";
+  @className('d')
+  c = '';
 
-  @attribute("href")
-  customHref = "http://emberjs.com";
+  @attribute('href')
+  customHref = 'http://emberjs.com';
 }
 
 @classic
@@ -105,16 +105,15 @@ class Foo extends EmberObject {
   /**
   Computed fullname
   */
-  @(computed("firstName", "lastName").readOnly())
+  @(computed('firstName', 'lastName').readOnly())
   get fullName() {
-    return super.fullName &&
-    `${this.get("firstName")} ${this.get("lastName")}`;
+    return super.fullName && `${this.get('firstName')} ${this.get('lastName')}`;
   }
 
   set fullName(value) {
     let [firstName, lastName] = value.split(/\s+/);
-    this.set("firstName", firstName);
-    this.set("lastName", lastName);
+    this.set('firstName', firstName);
+    this.set('lastName', lastName);
     return value;
   }
 
@@ -126,27 +125,25 @@ class Foo extends EmberObject {
     if (desc) {
       return desc;
     }
-    return `${this.get(
-      "fullName"
-    )}; Age: ${this.get("age")}; Country: ${this.get("country")}`;
+    return `${this.get('fullName')}; Age: ${this.get('age')}; Country: ${this.get('country')}`;
   }
 
   /**
    * Fname
    */
-  @alias("firstName")
+  @alias('firstName')
   fName;
 
   /**
    * Fname1
    */
-  @alias("firstName")
+  @alias('firstName')
   fName1;
 
   /**
    * Fname2
    */
-  @(computed("firstName", "lastName").readOnly())
+  @(computed('firstName', 'lastName').readOnly())
   get fName2() {
     return true;
   }
@@ -154,7 +151,7 @@ class Foo extends EmberObject {
   /**
    * Fname3
    */
-  @(computed("firstName", "lastName").volatile())
+  @(computed('firstName', 'lastName').volatile())
   get fName3() {
     return true;
   }
@@ -162,43 +159,43 @@ class Foo extends EmberObject {
   /**
    * Lname
    */
-  @(alias("firstName", "lastName").readOnly())
+  @(alias('firstName', 'lastName').readOnly())
   lName;
 
   /**
    * Lname1
    */
-  @add("description", "lastName")
+  @add('description', 'lastName')
   lName1;
 
   /**
    * Lname2
    */
-  @readOnly("description")
+  @readOnly('description')
   lName2;
 
   /**
    * Lname3
    */
-  @reads("description", "lastName")
+  @reads('description', 'lastName')
   lName3;
 
   /**
    * Lname4
    */
-  @enoWay("description", "lastName")
+  @enoWay('description', 'lastName')
   lName4;
 
   /**
    * Lname5
    */
-  @(add("description", "lastName").readOnly())
+  @(add('description', 'lastName').readOnly())
   lName5;
 
-  @(equal("limit", NUMERIC_CONSTANT.LIMIT).readOnly())
+  @(equal('limit', NUMERIC_CONSTANT.LIMIT).readOnly())
   isEqualToLimit;
 
-  @(gt("limit", NUMERIC_CONSTANT).readOnly())
+  @(gt('limit', NUMERIC_CONSTANT).readOnly())
   isGreaterThanLimit;
 }
 

--- a/transforms/ember-object/__testfixtures__/default-export.output.js
+++ b/transforms/ember-object/__testfixtures__/default-export.output.js
@@ -1,3 +1,3 @@
-import classic from "ember-classic-decorator";
+import classic from 'ember-classic-decorator';
 @classic
 export default class DefaultExportInput extends EmberObject {}

--- a/transforms/ember-object/__testfixtures__/double-quotes.input.js
+++ b/transforms/ember-object/__testfixtures__/double-quotes.input.js
@@ -5,10 +5,10 @@ const Foo = Test.extend(MyMixin, {
   /**
    * Property comments
    */
-  prop: 'defaultValue',
+  prop: "defaultValue",
   boolProp: true,
   numProp: 123,
-  [MY_VAL]: 'val',
+  [MY_VAL]: "val",
   queryParams: {},
   someVal,
 

--- a/transforms/ember-object/__testfixtures__/double-quotes.options.json
+++ b/transforms/ember-object/__testfixtures__/double-quotes.options.json
@@ -1,0 +1,3 @@
+{
+  "quote": "double"
+}

--- a/transforms/ember-object/__testfixtures__/double-quotes.output.js
+++ b/transforms/ember-object/__testfixtures__/double-quotes.output.js
@@ -1,4 +1,4 @@
-import classic from 'ember-classic-decorator';
+import classic from "ember-classic-decorator";
 
 /**
  * Program comments
@@ -8,11 +8,11 @@ class Foo extends Test.extend(MyMixin) {
   /**
    * Property comments
    */
-  prop = 'defaultValue';
+  prop = "defaultValue";
 
   boolProp = true;
   numProp = 123;
-  [MY_VAL] = 'val';
+  [MY_VAL] = "val";
   queryParams = {};
   someVal = someVal;
 

--- a/transforms/ember-object/__testfixtures__/import.input.js
+++ b/transforms/ember-object/__testfixtures__/import.input.js
@@ -1,13 +1,13 @@
-import Service from "@ember/service";
-import Controller from "@ember/controller";
-import Evented, { on } from "@ember/object/evented";
+import Service from '@ember/service';
+import Controller from '@ember/controller';
+import Evented, { on } from '@ember/object/evented';
 
 const ser = Service.extend({});
 const ctrl = Controller.extend({});
 const evt = Service.extend(Evented, {
-  e: on("click", function() {
-    return "e";
-  })
+  e: on('click', function() {
+    return 'e';
+  }),
 });
 
 export { ser, ctrl, evt };

--- a/transforms/ember-object/__testfixtures__/import.output.js
+++ b/transforms/ember-object/__testfixtures__/import.output.js
@@ -1,8 +1,8 @@
-import classic from "ember-classic-decorator";
-import { on } from "@ember-decorators/object";
-import Service from "@ember/service";
-import Controller from "@ember/controller";
-import Evented from "@ember/object/evented";
+import classic from 'ember-classic-decorator';
+import { on } from '@ember-decorators/object';
+import Service from '@ember/service';
+import Controller from '@ember/controller';
+import Evented from '@ember/object/evented';
 
 @classic
 class Ser extends Service {}
@@ -12,9 +12,9 @@ class Ctrl extends Controller {}
 
 @classic
 class Evt extends Service.extend(Evented) {
-  @on("click")
+  @on('click')
   e() {
-    return "e";
+    return 'e';
   }
 }
 

--- a/transforms/ember-object/__testfixtures__/runtime.input.js
+++ b/transforms/ember-object/__testfixtures__/runtime.input.js
@@ -1,6 +1,6 @@
-import RuntimeInput from "common/runtime/input";
-import { alias } from "@ember/object/computed";
-import { computed } from "@ember/object";
+import RuntimeInput from 'common/runtime/input';
+import { alias } from '@ember/object/computed';
+import { computed } from '@ember/object';
 
 /**
  * Program comments
@@ -9,20 +9,20 @@ export default RuntimeInput.extend(MyMixin, {
   /**
    * Property comments
    */
-  prop: "defaultValue",
+  prop: 'defaultValue',
   boolProp: true,
   numProp: 123,
-  [MY_VAL]: "val",
+  [MY_VAL]: 'val',
   queryParams: {},
 
   unobservedProp: null,
   offProp: null,
 
-  numPlusOne: computed("numProp", function() {
-    return this.get("numProp") + 1;
+  numPlusOne: computed('numProp', function() {
+    return this.get('numProp') + 1;
   }),
 
-  numPlusPlus: alias("numPlusOne"),
+  numPlusPlus: alias('numPlusOne'),
 
   computedMacro: customMacro(),
 
@@ -58,6 +58,6 @@ export default RuntimeInput.extend(MyMixin, {
 
     overriddenActionMethod() {
       this._super(...arguments) && this.boolProp;
-    }
-  }
+    },
+  },
 });

--- a/transforms/ember-object/__testfixtures__/runtime.output.js
+++ b/transforms/ember-object/__testfixtures__/runtime.output.js
@@ -1,8 +1,8 @@
-import classic from "ember-classic-decorator";
-import { off, unobserves } from "@ember-decorators/object";
-import { action, computed } from "@ember/object";
-import { alias } from "@ember/object/computed";
-import RuntimeInput from "common/runtime/input";
+import classic from 'ember-classic-decorator';
+import { off, unobserves } from '@ember-decorators/object';
+import { action, computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import RuntimeInput from 'common/runtime/input';
 
 /**
  * Program comments
@@ -12,25 +12,25 @@ export default class RuntimeInputEmberObject extends RuntimeInput.extend(MyMixin
   /**
    * Property comments
    */
-  prop = "defaultValue";
+  prop = 'defaultValue';
 
   boolProp = true;
   numProp = 123;
-  [MY_VAL] = "val";
+  [MY_VAL] = 'val';
   queryParams = {};
 
-  @unobserves("prop3", "prop4")
+  @unobserves('prop3', 'prop4')
   unobservedProp;
 
-  @off("prop1", "prop2")
+  @off('prop1', 'prop2')
   offProp;
 
-  @computed("numProp")
+  @computed('numProp')
   get numPlusOne() {
-    return this.get("numProp") + 1;
+    return this.get('numProp') + 1;
   }
 
-  @alias("numPlusOne")
+  @alias('numPlusOne')
   numPlusPlus;
 
   @customMacro

--- a/transforms/ember-object/__testfixtures__/single-quotes.input.js
+++ b/transforms/ember-object/__testfixtures__/single-quotes.input.js
@@ -31,7 +31,7 @@ const Foo = Test.extend(MyMixin, {
 
   anotherMethod() {
     this._super(...arguments);
-  }
+  },
 });
 
 const Foo = EmberObject.extend(MixinA, MixinB);

--- a/transforms/ember-object/__testfixtures__/single-quotes.options.json
+++ b/transforms/ember-object/__testfixtures__/single-quotes.options.json
@@ -1,3 +1,0 @@
-{
-  "quote": "single"
-}

--- a/transforms/ember-object/__testfixtures__/types/services/basic.output.js
+++ b/transforms/ember-object/__testfixtures__/types/services/basic.output.js
@@ -1,4 +1,4 @@
-import classic from "ember-classic-decorator";
+import classic from 'ember-classic-decorator';
 
 /**
  * Program comments

--- a/transforms/ember-object/index.js
+++ b/transforms/ember-object/index.js
@@ -1,11 +1,11 @@
-const { getOptions } = require("codemod-cli");
-const { replaceEmberObjectExpressions } = require("../helpers/parse-helper");
+const { getOptions } = require('codemod-cli');
+const { replaceEmberObjectExpressions } = require('../helpers/parse-helper');
 
 const DEFAULT_OPTIONS = {
   decorators: true,
   classFields: true,
   classicDecorator: true,
-  quote: "double"
+  quote: 'double',
 };
 
 module.exports = function transformer(file, api) {
@@ -18,11 +18,11 @@ module.exports = function transformer(file, api) {
   const replaced = replaceEmberObjectExpressions(j, root, path, options);
   if (replaced) {
     source = root.toSource({
-      quote: options.quotes || options.quote
+      quote: options.quotes || options.quote,
     });
   }
   return source;
 };
 
 // Set the parser, needed for supporting decorators
-module.exports.parser = "flow";
+module.exports.parser = 'flow';

--- a/transforms/ember-object/index.js
+++ b/transforms/ember-object/index.js
@@ -5,7 +5,7 @@ const DEFAULT_OPTIONS = {
   decorators: true,
   classFields: true,
   classicDecorator: true,
-  quote: 'double',
+  quote: 'single',
 };
 
 module.exports = function transformer(file, api) {

--- a/transforms/ember-object/test.js
+++ b/transforms/ember-object/test.js
@@ -1,21 +1,21 @@
-"use strict";
+'use strict';
 
-const { runTransformTest } = require("codemod-cli");
+const { runTransformTest } = require('codemod-cli');
 
 // bootstrap the mock telemetry data
-const walkSync = require("walk-sync");
-const mockTelemetryData = require("./__testfixtures__/-mock-telemetry.json");
+const walkSync = require('walk-sync');
+const mockTelemetryData = require('./__testfixtures__/-mock-telemetry.json');
 
-const cache = require("../../lib/cache");
+const cache = require('../../lib/cache');
 
 // This is nasty, cwd is screwed up here for some reason
-let testFiles = walkSync("./transforms/ember-object/__testfixtures__", {
-  globs: ["**/*.input.js"]
+let testFiles = walkSync('./transforms/ember-object/__testfixtures__', {
+  globs: ['**/*.input.js'],
 });
 let mockTelemetry = {};
 
 for (let testFile of testFiles) {
-  let moduleName = testFile.replace(/\.[^/.]+$/, "");
+  let moduleName = testFile.replace(/\.[^/.]+$/, '');
   let value = mockTelemetryData[moduleName] || {};
 
   mockTelemetry[
@@ -23,9 +23,9 @@ for (let testFile of testFiles) {
   ] = value;
 }
 
-cache.set("telemetry", JSON.stringify(mockTelemetry));
+cache.set('telemetry', JSON.stringify(mockTelemetry));
 
 runTransformTest({
-  type: "jscodeshift",
-  name: "ember-object"
+  type: 'jscodeshift',
+  name: 'ember-object',
 });

--- a/transforms/helpers/EOProp.js
+++ b/transforms/helpers/EOProp.js
@@ -5,8 +5,8 @@ const {
   getModifier,
   isClassDecoratorProp,
   LAYOUT_DECORATOR_LOCAL_NAME,
-  LAYOUT_DECORATOR_NAME
-} = require("./util");
+  LAYOUT_DECORATOR_NAME,
+} = require('./util');
 
 /**
  * Ember Objet Property
@@ -22,19 +22,19 @@ class EOProp {
   }
 
   get value() {
-    return get(this._prop, "value");
+    return get(this._prop, 'value');
   }
 
   get kind() {
-    let kind = get(this._prop, "kind");
-    if (kind === "init" && this.hasDecorators && !this.hasMethodDecorator) {
-      kind = "get";
+    let kind = get(this._prop, 'kind');
+    if (kind === 'init' && this.hasDecorators && !this.hasMethodDecorator) {
+      kind = 'get';
     }
     return kind;
   }
 
   get key() {
-    return get(this._prop, "key");
+    return get(this._prop, 'key');
   }
 
   get name() {
@@ -46,7 +46,7 @@ class EOProp {
   }
 
   get calleeName() {
-    return get(this.calleeObject, "callee.name");
+    return get(this.calleeObject, 'callee.name');
   }
 
   get comments() {
@@ -62,10 +62,7 @@ class EOProp {
   }
 
   get classDecoratorName() {
-    if (
-      this.name === LAYOUT_DECORATOR_NAME &&
-      this.value.name === LAYOUT_DECORATOR_NAME
-    ) {
+    if (this.name === LAYOUT_DECORATOR_NAME && this.value.name === LAYOUT_DECORATOR_NAME) {
       return LAYOUT_DECORATOR_LOCAL_NAME;
     }
     return this.name;
@@ -80,7 +77,7 @@ class EOProp {
   }
 
   get isCallExpression() {
-    return this.type === "CallExpression";
+    return this.type === 'CallExpression';
   }
 
   get hasDecorators() {
@@ -88,7 +85,7 @@ class EOProp {
   }
 
   get callExprArgs() {
-    return get(this.calleeObject, "arguments") || [];
+    return get(this.calleeObject, 'arguments') || [];
   }
 
   get shouldRemoveLastArg() {
@@ -96,8 +93,7 @@ class EOProp {
 
     return (
       lastArg.length > 0 &&
-      (lastArg[0].type === "FunctionExpression" ||
-        lastArg[0].type === "ObjectExpression")
+      (lastArg[0].type === 'FunctionExpression' || lastArg[0].type === 'ObjectExpression')
     );
   }
 
@@ -106,15 +102,11 @@ class EOProp {
   }
 
   get hasVolatile() {
-    return this.modifiers.some(
-      modifier => get(modifier, "prop.name") === "volatile"
-    );
+    return this.modifiers.some(modifier => get(modifier, 'prop.name') === 'volatile');
   }
 
   get hasReadOnly() {
-    return this.modifiers.some(
-      modifier => get(modifier, "prop.name") === "readOnly"
-    );
+    return this.modifiers.some(modifier => get(modifier, 'prop.name') === 'readOnly');
   }
 
   get isVolatileReadOnly() {
@@ -122,35 +114,35 @@ class EOProp {
   }
 
   get isTagName() {
-    return this.name === "tagName";
+    return this.name === 'tagName';
   }
 
   get isClassNames() {
-    return this.name === "classNames";
+    return this.name === 'classNames';
   }
 
   get isAction() {
-    return this.name === "actions";
+    return this.name === 'actions';
   }
 
   get hasClassNameDecorator() {
-    return this.decoratorNames.includes("className");
+    return this.decoratorNames.includes('className');
   }
 
   get hasAttributeDecorator() {
-    return this.decoratorNames.includes("attribute");
+    return this.decoratorNames.includes('attribute');
   }
 
   get hasUnobservesDecorator() {
-    return this.decoratorNames.includes("unobserves");
+    return this.decoratorNames.includes('unobserves');
   }
 
   get hasOffDecorator() {
-    return this.decoratorNames.includes("off");
+    return this.decoratorNames.includes('off');
   }
 
   get hasWrapComputedDecorator() {
-    return this.decoratorNames.includes("wrapComputed");
+    return this.decoratorNames.includes('wrapComputed');
   }
 
   get hasRuntimeData() {
@@ -158,10 +150,10 @@ class EOProp {
   }
 
   setCallExpressionProps() {
-    let calleeObject = get(this._prop, "value");
+    let calleeObject = get(this._prop, 'value');
     const modifiers = [getModifier(calleeObject)];
-    while (get(calleeObject, "callee.type") === "MemberExpression") {
-      calleeObject = get(calleeObject, "callee.object");
+    while (get(calleeObject, 'callee.type') === 'MemberExpression') {
+      calleeObject = get(calleeObject, 'callee.object');
       modifiers.push(getModifier(calleeObject));
     }
     this.calleeObject = calleeObject;
@@ -172,16 +164,12 @@ class EOProp {
   setDecorators(importedDecoratedProps) {
     if (this.isCallExpression) {
       this.setCallExpressionProps();
-      const {
-        decoratorName,
-        isMethodDecorator,
-        isMetaDecorator,
-        importedName
-      } = importedDecoratedProps[this.calleeName] || {};
+      const { decoratorName, isMethodDecorator, isMetaDecorator, importedName } =
+        importedDecoratedProps[this.calleeName] || {};
       if (decoratorName) {
-        this.hasMapDecorator = importedName === "map";
-        this.hasFilterDecorator = importedName === "filter";
-        this.hasComputedDecorator = importedName === "computed";
+        this.hasMapDecorator = importedName === 'map';
+        this.hasFilterDecorator = importedName === 'filter';
+        this.hasComputedDecorator = importedName === 'computed';
         this.hasMethodDecorator = isMethodDecorator;
         this.hasMetaDecorator = isMetaDecorator;
         this.decoratorNames.push(decoratorName);
@@ -191,10 +179,10 @@ class EOProp {
 
   addBindingProps(attributeBindingsProps, classNameBindingsProps) {
     if (attributeBindingsProps[this.name]) {
-      this.decoratorNames.push("attribute");
+      this.decoratorNames.push('attribute');
       this.propList = attributeBindingsProps[this.name];
     } else if (classNameBindingsProps[this.name]) {
-      this.decoratorNames.push("className");
+      this.decoratorNames.push('className');
       this.propList = classNameBindingsProps[this.name];
     }
   }
@@ -207,27 +195,23 @@ class EOProp {
     overriddenActions = [],
     overriddenProperties = [],
     // ownProperties = [],
-    type = "",
-    unobservedProperties = {}
+    type = '',
+    unobservedProperties = {},
   }) {
     if (!type) {
       return;
     }
     const name = this.name;
     if (Object.keys(unobservedProperties).includes(name)) {
-      this.decoratorNames.push("unobserves");
-      this.decoratorArgs["unobserves"] = unobservedProperties[name];
+      this.decoratorNames.push('unobserves');
+      this.decoratorArgs['unobserves'] = unobservedProperties[name];
     }
     if (Object.keys(offProperties).includes(name)) {
-      this.decoratorNames.push("off");
-      this.decoratorArgs["off"] = offProperties[name];
+      this.decoratorNames.push('off');
+      this.decoratorArgs['off'] = offProperties[name];
     }
-    if (
-      computedProperties.includes(name) &&
-      !this.hasComputedDecorator &&
-      !this.hasMetaDecorator
-    ) {
-      this.decoratorNames.push("wrapComputed");
+    if (computedProperties.includes(name) && !this.hasComputedDecorator && !this.hasMetaDecorator) {
+      this.decoratorNames.push('wrapComputed');
     }
     if (this.isAction) {
       this.overriddenActions = overriddenActions;

--- a/transforms/helpers/decorator-helper.js
+++ b/transforms/helpers/decorator-helper.js
@@ -1,4 +1,4 @@
-const { get } = require("./util");
+const { get } = require('./util');
 
 /**
  * Copy decorators `from` => `to`
@@ -22,15 +22,13 @@ function withDecorators(to, decorators = []) {
  */
 function createClassDecorator(j, classDecoratorProp) {
   let decoratorArgs = [];
-  if (classDecoratorProp.type === "ArrayExpression") {
+  if (classDecoratorProp.type === 'ArrayExpression') {
     decoratorArgs = classDecoratorProp.value.elements;
   } else {
     decoratorArgs = [classDecoratorProp.value];
   }
   return j.decorator(
-    j.callExpression(j.identifier(classDecoratorProp.classDecoratorName), [
-      ...decoratorArgs
-    ])
+    j.callExpression(j.identifier(classDecoratorProp.classDecoratorName), [...decoratorArgs])
   );
 }
 
@@ -61,10 +59,7 @@ function createCallExpressionDecorators(j, decoratorName, instanceProp) {
 
   const decoratorExpr = instanceProp.modifiers.reduce(
     (callExpr, modifier) =>
-      j.callExpression(
-        j.memberExpression(callExpr, modifier.prop),
-        modifier.args
-      ),
+      j.callExpression(j.memberExpression(callExpr, modifier.prop), modifier.args),
     j.callExpression(j.identifier(decoratorName), decoratorArgs)
   );
 
@@ -74,7 +69,7 @@ function createCallExpressionDecorators(j, decoratorName, instanceProp) {
 
   // If has modifiers wrap decorators in anonymous call expression
   // it transforms @computed('').readOnly() => @(computed('').readOnly())
-  return j.decorator(j.callExpression(j.identifier(""), [decoratorExpr]));
+  return j.decorator(j.callExpression(j.identifier(''), [decoratorExpr]));
 }
 
 /**
@@ -86,14 +81,7 @@ function createCallExpressionDecorators(j, decoratorName, instanceProp) {
  * @returns {Decorator[]}
  */
 function createDecoratorsWithArgs(j, identifier, args) {
-  return [
-    j.decorator(
-      j.callExpression(
-        j.identifier(identifier),
-        args.map(arg => j.literal(arg))
-      )
-    )
-  ];
+  return [j.decorator(j.callExpression(j.identifier(identifier), args.map(arg => j.literal(arg))))];
 }
 
 /**
@@ -103,7 +91,7 @@ function createDecoratorsWithArgs(j, identifier, args) {
  * @param {String} identifier
  * @returns {Decorator[]}
  */
-function createIdentifierDecorators(j, identifier = "action") {
+function createIdentifierDecorators(j, identifier = 'action') {
   return [j.decorator(j.identifier(identifier))];
 }
 
@@ -116,12 +104,10 @@ function createIdentifierDecorators(j, identifier = "action") {
  * @returns {Decorator[]}
  */
 function createBindingDecorators(j, decoratorName, instanceProp) {
-  const propList = get(instanceProp, "propList");
+  const propList = get(instanceProp, 'propList');
   if (propList && propList.length) {
     const propArgs = propList.map(prop => j.literal(prop));
-    return [
-      j.decorator(j.callExpression(j.identifier(decoratorName), propArgs))
-    ];
+    return [j.decorator(j.callExpression(j.identifier(decoratorName), propArgs))];
   }
   return [j.decorator(j.identifier(decoratorName))];
 }
@@ -138,23 +124,15 @@ function createInstancePropDecorators(j, instanceProp) {
     if (!decorator) {
       return decorators;
     }
-    if (decorator === "className" || decorator === "attribute") {
+    if (decorator === 'className' || decorator === 'attribute') {
+      return decorators.concat(createBindingDecorators(j, decorator, instanceProp));
+    }
+    if (decorator === 'off' || decorator === 'unobserves') {
       return decorators.concat(
-        createBindingDecorators(j, decorator, instanceProp)
+        createDecoratorsWithArgs(j, decorator, instanceProp.decoratorArgs[decorator])
       );
     }
-    if (decorator === "off" || decorator === "unobserves") {
-      return decorators.concat(
-        createDecoratorsWithArgs(
-          j,
-          decorator,
-          instanceProp.decoratorArgs[decorator]
-        )
-      );
-    }
-    return decorators.concat(
-      createCallExpressionDecorators(j, decorator, instanceProp)
-    );
+    return decorators.concat(createCallExpressionDecorators(j, decorator, instanceProp));
   }, []);
 }
 
@@ -163,5 +141,5 @@ module.exports = {
   createClassDecorator,
   createIdentifierDecorators,
   createCallExpressionDecorators,
-  createInstancePropDecorators
+  createInstancePropDecorators,
 };

--- a/transforms/helpers/import-helper.js
+++ b/transforms/helpers/import-helper.js
@@ -4,12 +4,9 @@ const {
   EMBER_DECORATOR_SPECIFIERS,
   get,
   getFirstDeclaration,
-  METHOD_DECORATORS
-} = require("./util");
-const {
-  createEmberDecoratorSpecifiers,
-  createImportDeclaration
-} = require("./transform-helper");
+  METHOD_DECORATORS,
+} = require('./util');
+const { createEmberDecoratorSpecifiers, createImportDeclaration } = require('./transform-helper');
 
 /**
  * Return the decorator name for the specifier if any, using the importPropDecoratorMap from
@@ -20,8 +17,8 @@ const {
  * @returns {String}
  */
 function getDecoratorInfo(specifier, importPropDecoratorMap) {
-  const localName = get(specifier, "local.name");
-  const importedName = get(specifier, "imported.name");
+  const localName = get(specifier, 'local.name');
+  const importedName = get(specifier, 'imported.name');
   const isImportedAs = importedName !== localName;
   const isMetaDecorator = !importPropDecoratorMap;
   let decoratorName;
@@ -42,7 +39,7 @@ function getDecoratorInfo(specifier, importPropDecoratorMap) {
     isImportedAs,
     isMetaDecorator,
     isMethodDecorator,
-    localName
+    localName,
   };
 }
 
@@ -54,7 +51,7 @@ function getDecoratorInfo(specifier, importPropDecoratorMap) {
  * @returns {Boolean}
  */
 function isSpecifierDecorator(specifier, importPropDecoratorMap) {
-  const importedName = get(specifier, "imported.name");
+  const importedName = get(specifier, 'imported.name');
   if (!importPropDecoratorMap || importPropDecoratorMap[importedName]) {
     return true;
   }
@@ -67,7 +64,7 @@ function isSpecifierDecorator(specifier, importPropDecoratorMap) {
  * @returns {String} local name
  */
 function getSpecifierLocalIdentifier(specifier) {
-  if (get(specifier, "local.name") === get(specifier, "imported.name")) {
+  if (get(specifier, 'local.name') === get(specifier, 'imported.name')) {
     return null;
   }
   return specifier.local;
@@ -84,10 +81,7 @@ function getSpecifierLocalIdentifier(specifier) {
 function setSpecifierNames(specifier, importPropDecoratorMap) {
   specifier.local = getSpecifierLocalIdentifier(specifier);
   if (importPropDecoratorMap) {
-    const decoratorImportedName = get(
-      importPropDecoratorMap,
-      get(specifier, "imported.name")
-    );
+    const decoratorImportedName = get(importPropDecoratorMap, get(specifier, 'imported.name'));
     specifier.imported.name = decoratorImportedName;
     // Needed one more time as we changed the imported name
     specifier.local = getSpecifierLocalIdentifier(specifier);
@@ -107,8 +101,8 @@ function getExistingDecoratorImports(j, root) {
   return Object.keys(DECORATOR_PATHS).reduce((imports, path) => {
     const decoratorImports = root.find(j.ImportDeclaration, {
       source: {
-        value: path
-      }
+        value: path,
+      },
     });
 
     if (decoratorImports.length) {
@@ -141,8 +135,8 @@ function createNewImportDeclarations(
     firstDeclaration.insertBefore(
       createImportDeclaration(
         j,
-        [j.importDefaultSpecifier(j.identifier("classic"))],
-        "ember-classic-decorator"
+        [j.importDefaultSpecifier(j.identifier('classic'))],
+        'ember-classic-decorator'
       )
     );
   }
@@ -158,9 +152,7 @@ function createNewImportDeclarations(
       );
 
       if (specifiers.length) {
-        firstDeclaration.insertBefore(
-          createImportDeclaration(j, specifiers, path)
-        );
+        firstDeclaration.insertBefore(createImportDeclaration(j, specifiers, path));
       }
     });
 }
@@ -190,7 +182,7 @@ function getDecoratorPathSpecifiers(j, root, decoratorsToImport = []) {
   return getExistingDecoratorImports(j, root).reduce(
     (decoratorPathSpecifierMap, existingDecoratorImport) => {
       const { importPropDecoratorMap, decoratorPath } = DECORATOR_PATHS[
-        get(existingDecoratorImport, "value.source.value")
+        get(existingDecoratorImport, 'value.source.value')
       ];
       // Decorators to be imported for the path
       // These are typically additional decorators which need to be imported for a path
@@ -206,8 +198,7 @@ function getDecoratorPathSpecifiers(j, root, decoratorsToImport = []) {
         decoratorsForPath,
         decoratorsToImport
       );
-      const existingSpecifiers =
-        get(existingDecoratorImport, "value.specifiers") || [];
+      const existingSpecifiers = get(existingDecoratorImport, 'value.specifiers') || [];
 
       // Iterate over existing specifiers for the current path. This is needed
       // to pick the only required specifiers from the existing imports
@@ -221,8 +212,7 @@ function getDecoratorPathSpecifiers(j, root, decoratorsToImport = []) {
           setSpecifierNames(existingSpecifier, importPropDecoratorMap);
           // Check if the decorator import path is overridden
           // Needed in case of `observes` which need to be imported from `@ember-decorators/object`
-          const overriddenPath =
-            DECORATOR_PATH_OVERRIDES[get(existingSpecifier, "imported.name")];
+          const overriddenPath = DECORATOR_PATH_OVERRIDES[get(existingSpecifier, 'imported.name')];
           if (overriddenPath) {
             decoratorPathSpecifierMap[overriddenPath] = [].concat(
               decoratorPathSpecifierMap[overriddenPath] || [],
@@ -231,9 +221,8 @@ function getDecoratorPathSpecifiers(j, root, decoratorsToImport = []) {
           } else {
             const isSpecifierPresent = decoratedSpecifiers.some(specifier => {
               return (
-                !get(specifier, "local.name") &&
-                get(specifier, "imported.name") ===
-                  get(existingSpecifier, "imported.name")
+                !get(specifier, 'local.name') &&
+                get(specifier, 'imported.name') === get(existingSpecifier, 'imported.name')
               );
             });
             if (!isSpecifierPresent) {
@@ -274,8 +263,8 @@ function getDecoratorPathSpecifiers(j, root, decoratorsToImport = []) {
 function getExistingImportForPath(j, root, importPath) {
   const decoratorImports = root.find(j.ImportDeclaration, {
     source: {
-      value: importPath
-    }
+      value: importPath,
+    },
   });
 
   if (decoratorImports.length) {
@@ -295,18 +284,9 @@ function getExistingImportForPath(j, root, importPath) {
  * @param {File} root
  * @param {String[]} decoratorsToImport
  */
-function createDecoratorImportDeclarations(
-  j,
-  root,
-  decoratorsToImport = [],
-  options = {}
-) {
+function createDecoratorImportDeclarations(j, root, decoratorsToImport = [], options = {}) {
   // Iterate through existing imports, extract the already imported specifiers
-  const decoratorPathSpecifierMap = getDecoratorPathSpecifiers(
-    j,
-    root,
-    decoratorsToImport
-  );
+  const decoratorPathSpecifierMap = getDecoratorPathSpecifiers(j, root, decoratorsToImport);
 
   const firstDeclaration = getFirstDeclaration(j, root);
   const decoratorPathsImported = Object.keys(decoratorPathSpecifierMap);
@@ -315,28 +295,17 @@ function createDecoratorImportDeclarations(
     const specifiers = decoratorPathSpecifierMap[decoratorPath];
     const existingImport = getExistingImportForPath(j, root, decoratorPath);
     if (existingImport) {
-      let existingSpecifiers = get(existingImport, "value.specifiers");
+      let existingSpecifiers = get(existingImport, 'value.specifiers');
       if (existingSpecifiers) {
-        existingImport.value.specifiers = [].concat(
-          existingSpecifiers,
-          specifiers
-        );
+        existingImport.value.specifiers = [].concat(existingSpecifiers, specifiers);
       }
     } else {
-      firstDeclaration.insertBefore(
-        createImportDeclaration(j, specifiers, decoratorPath)
-      );
+      firstDeclaration.insertBefore(createImportDeclaration(j, specifiers, decoratorPath));
     }
   });
 
   // Create new import declarations
-  createNewImportDeclarations(
-    j,
-    root,
-    decoratorsToImport,
-    decoratorPathsImported,
-    options
-  );
+  createNewImportDeclarations(j, root, decoratorsToImport, decoratorPathsImported, options);
 }
 
 /**
@@ -347,29 +316,24 @@ function createDecoratorImportDeclarations(
  * @returns {Object}
  */
 function getImportedDecoratedProps(j, root) {
-  return getExistingDecoratorImports(j, root).reduce(
-    (importedDecorators, decoratorImport) => {
-      const { importPropDecoratorMap } = DECORATOR_PATHS[
-        get(decoratorImport, "value.source.value")
-      ];
+  return getExistingDecoratorImports(j, root).reduce((importedDecorators, decoratorImport) => {
+    const { importPropDecoratorMap } = DECORATOR_PATHS[get(decoratorImport, 'value.source.value')];
 
-      const specifiers = get(decoratorImport, "value.specifiers") || [];
+    const specifiers = get(decoratorImport, 'value.specifiers') || [];
 
-      return specifiers.reduce((importedDecorators, specifier) => {
-        if (isSpecifierDecorator(specifier, importPropDecoratorMap)) {
-          importedDecorators[get(specifier, "local.name")] = getDecoratorInfo(
-            specifier,
-            importPropDecoratorMap
-          );
-        }
-        return importedDecorators;
-      }, importedDecorators);
-    },
-    {}
-  );
+    return specifiers.reduce((importedDecorators, specifier) => {
+      if (isSpecifierDecorator(specifier, importPropDecoratorMap)) {
+        importedDecorators[get(specifier, 'local.name')] = getDecoratorInfo(
+          specifier,
+          importPropDecoratorMap
+        );
+      }
+      return importedDecorators;
+    }, importedDecorators);
+  }, {});
 }
 
 module.exports = {
   createDecoratorImportDeclarations,
-  getImportedDecoratedProps
+  getImportedDecoratedProps,
 };

--- a/transforms/helpers/log-helper.js
+++ b/transforms/helpers/log-helper.js
@@ -1,4 +1,4 @@
-const { createLogger, format, transports } = require("winston");
+const { createLogger, format, transports } = require('winston');
 const { combine, timestamp, printf } = format;
 
 const logFormatter = printf(info => {
@@ -7,5 +7,5 @@ const logFormatter = printf(info => {
 
 module.exports = createLogger({
   format: combine(timestamp(), logFormatter),
-  transports: [new transports.File({ filename: "codemods.log" })]
+  transports: [new transports.File({ filename: 'codemods.log' })],
 });

--- a/transforms/helpers/util/get-telemetry-for.js
+++ b/transforms/helpers/util/get-telemetry-for.js
@@ -1,22 +1,20 @@
-const fs = require("fs-extra");
-const path = require("path");
-const walkSync = require("walk-sync");
-const cache = require("../../../lib/cache");
+const fs = require('fs-extra');
+const path = require('path');
+const walkSync = require('walk-sync');
+const cache = require('../../../lib/cache');
 
-const telemetry = cache.has("telemetry")
-  ? JSON.parse(cache.get("telemetry").value)
-  : {};
+const telemetry = cache.has('telemetry') ? JSON.parse(cache.get('telemetry').value) : {};
 const ADDON_PATHS = {};
 
-let packagePaths = walkSync("./", {
-  globs: ["**/package.json"],
-  ignore: ["node_modules/**"]
+let packagePaths = walkSync('./', {
+  globs: ['**/package.json'],
+  ignore: ['node_modules/**'],
 });
 
 for (let packagePath of packagePaths) {
   let { name } = fs.readJsonSync(packagePath);
 
-  ADDON_PATHS[path.dirname(path.resolve(".", packagePath))] = name;
+  ADDON_PATHS[path.dirname(path.resolve('.', packagePath))] = name;
 }
 
 /**
@@ -26,24 +24,24 @@ for (let packagePath of packagePaths) {
  * @returns {String} The in-browser module path for the specified filePath
  */
 function getModulePathFor(filePath, addonPaths = ADDON_PATHS) {
-  let fileSegments = filePath.split("/");
+  let fileSegments = filePath.split('/');
   let addonSegments = [];
 
   while (fileSegments.length > 0) {
     addonSegments.push(fileSegments.shift());
 
-    if (addonPaths[addonSegments.join("/")]) {
+    if (addonPaths[addonSegments.join('/')]) {
       break;
     }
   }
 
-  let addonFilePath = addonSegments.join("/");
+  let addonFilePath = addonSegments.join('/');
   let addonName = addonPaths[addonFilePath];
 
   let relativeFilePath = fileSegments
-    .join("/")
-    .replace(/^(addon|app)\//, "")
-    .replace(/\.[^/.]+$/, "");
+    .join('/')
+    .replace(/^(addon|app)\//, '')
+    .replace(/\.[^/.]+$/, '');
 
   return `${addonName}/${relativeFilePath}`;
 }
@@ -62,5 +60,5 @@ function getTelemetryFor(filePath) {
 
 module.exports = {
   getTelemetryFor,
-  getModulePathFor
+  getModulePathFor,
 };

--- a/transforms/helpers/util/get-telemetry-for.test.js
+++ b/transforms/helpers/util/get-telemetry-for.test.js
@@ -1,17 +1,16 @@
-const { getModulePathFor } = require("./get-telemetry-for");
+const { getModulePathFor } = require('./get-telemetry-for');
 
-describe("getModulePathFor", () => {
-  test("accesses telemetry data for the specified app module", () => {
+describe('getModulePathFor', () => {
+  test('accesses telemetry data for the specified app module', () => {
     const addonPaths = {
-      "/User/whomever/voyager-web/lib/invitation-platform":
-        "invitation-platform"
+      '/User/whomever/voyager-web/lib/invitation-platform': 'invitation-platform',
     };
 
     expect(
       getModulePathFor(
-        "/User/whomever/voyager-web/lib/invitation-platform/addon/components/fuse-limit-alert",
+        '/User/whomever/voyager-web/lib/invitation-platform/addon/components/fuse-limit-alert',
         addonPaths
       )
-    ).toEqual("invitation-platform/components/fuse-limit-alert");
+    ).toEqual('invitation-platform/components/fuse-limit-alert');
   });
 });

--- a/transforms/helpers/util/index.js
+++ b/transforms/helpers/util/index.js
@@ -1,149 +1,149 @@
-const LAYOUT_DECORATOR_NAME = "layout";
-const LAYOUT_DECORATOR_LOCAL_NAME = "templateLayout";
+const LAYOUT_DECORATOR_NAME = 'layout';
+const LAYOUT_DECORATOR_LOCAL_NAME = 'templateLayout';
 
 const DECORATOR_PATHS = {
-  "@ember/object": {
+  '@ember/object': {
     importPropDecoratorMap: {
-      observer: "observes",
-      computed: "computed"
+      observer: 'observes',
+      computed: 'computed',
     },
-    decoratorPath: "@ember/object"
+    decoratorPath: '@ember/object',
   },
-  "@ember/object/evented": {
+  '@ember/object/evented': {
     importPropDecoratorMap: {
-      on: "on"
+      on: 'on',
     },
-    decoratorPath: "@ember-decorators/object"
+    decoratorPath: '@ember-decorators/object',
   },
-  "@ember/controller": {
+  '@ember/controller': {
     importPropDecoratorMap: {
-      inject: "inject"
+      inject: 'inject',
     },
-    decoratorPath: "@ember/controller"
+    decoratorPath: '@ember/controller',
   },
-  "@ember/service": {
+  '@ember/service': {
     importPropDecoratorMap: {
-      inject: "inject"
+      inject: 'inject',
     },
-    decoratorPath: "@ember/service"
+    decoratorPath: '@ember/service',
   },
-  "@ember/object/computed": {
-    decoratorPath: "@ember/object/computed"
-  }
+  '@ember/object/computed': {
+    decoratorPath: '@ember/object/computed',
+  },
 };
 
 const DECORATOR_PATH_OVERRIDES = {
-  observes: "@ember-decorators/object"
+  observes: '@ember-decorators/object',
 };
 
 const EMBER_DECORATOR_SPECIFIERS = {
-  "@ember/object": ["action"],
-  "@ember-decorators/object": ["off", "on", "unobserves"],
-  "@ember-decorators/component": [
-    "attribute",
-    "className",
-    "classNames",
+  '@ember/object': ['action'],
+  '@ember-decorators/object': ['off', 'on', 'unobserves'],
+  '@ember-decorators/component': [
+    'attribute',
+    'className',
+    'classNames',
     LAYOUT_DECORATOR_NAME,
-    "tagName",
-    LAYOUT_DECORATOR_LOCAL_NAME
-  ]
+    'tagName',
+    LAYOUT_DECORATOR_LOCAL_NAME,
+  ],
 };
 
-const METHOD_DECORATORS = ["action", "on", "observer"];
+const METHOD_DECORATORS = ['action', 'on', 'observer'];
 
 const ACTION_SUPER_EXPRESSION_COMMENT = [
-  " TODO: This call to super is within an action, and has to refer to the parent",
+  ' TODO: This call to super is within an action, and has to refer to the parent',
   " class's actions to be safe. This should be refactored to call a normal method",
-  " on the parent class. If the parent class has not been converted to native",
-  " classes, it may need to be refactored as well. See",
-  " https: //github.com/scalvert/ember-es6-class-codemod/blob/master/README.md",
-  " for more details."
+  ' on the parent class. If the parent class has not been converted to native',
+  ' classes, it may need to be refactored as well. See',
+  ' https: //github.com/scalvert/ember-es6-class-codemod/blob/master/README.md',
+  ' for more details.',
 ];
 
 const LIFECYCLE_HOOKS = [
   // Methods
-  "$",
-  "addObserver",
-  "cacheFor",
-  "decrementProperty",
-  "destroy",
-  "didReceiveAttrs",
-  "didRender",
-  "didUpdate",
-  "didUpdateAttrs",
-  "get",
-  "getProperties",
-  "getWithDefault",
-  "has",
-  "incrementProperty",
-  "init",
-  "notifyPropertyChange",
-  "off",
-  "on",
-  "one",
-  "readDOMAttr",
-  "removeObserver",
-  "rerender",
-  "send",
-  "set",
-  "setProperties",
-  "toString",
-  "toggleProperty",
-  "trigger",
-  "willDestroy",
-  "willRender",
-  "willUpdate",
+  '$',
+  'addObserver',
+  'cacheFor',
+  'decrementProperty',
+  'destroy',
+  'didReceiveAttrs',
+  'didRender',
+  'didUpdate',
+  'didUpdateAttrs',
+  'get',
+  'getProperties',
+  'getWithDefault',
+  'has',
+  'incrementProperty',
+  'init',
+  'notifyPropertyChange',
+  'off',
+  'on',
+  'one',
+  'readDOMAttr',
+  'removeObserver',
+  'rerender',
+  'send',
+  'set',
+  'setProperties',
+  'toString',
+  'toggleProperty',
+  'trigger',
+  'willDestroy',
+  'willRender',
+  'willUpdate',
 
   // Events
-  "didInsertElement",
-  "didReceiveAttrs",
-  "didRender",
-  "didUpdate",
-  "didUpdateAttrs",
-  "willClearRender",
-  "willDestroyElement",
-  "willInsertElement",
-  "willRender",
-  "willUpdate",
+  'didInsertElement',
+  'didReceiveAttrs',
+  'didRender',
+  'didUpdate',
+  'didUpdateAttrs',
+  'willClearRender',
+  'willDestroyElement',
+  'willInsertElement',
+  'willRender',
+  'willUpdate',
 
   // Touch events
-  "touchStart",
-  "touchMove",
-  "touchEnd",
-  "touchCancel",
+  'touchStart',
+  'touchMove',
+  'touchEnd',
+  'touchCancel',
 
   // Keyboard events
-  "keyDown",
-  "keyUp",
-  "keyPress",
+  'keyDown',
+  'keyUp',
+  'keyPress',
 
   // Mouse events
-  "mouseDown",
-  "mouseUp",
-  "contextMenu",
-  "click",
-  "doubleClick",
-  "mouseMove",
-  "focusIn",
-  "focusOut",
-  "mouseEnter",
-  "mouseLeave",
+  'mouseDown',
+  'mouseUp',
+  'contextMenu',
+  'click',
+  'doubleClick',
+  'mouseMove',
+  'focusIn',
+  'focusOut',
+  'mouseEnter',
+  'mouseLeave',
 
   // Form events
-  "submit",
-  "change",
-  "focusIn",
-  "focusOut",
-  "input",
+  'submit',
+  'change',
+  'focusIn',
+  'focusOut',
+  'input',
 
   // HTML5 drag and drop events
-  "dragStart",
-  "drag",
-  "dragEnter",
-  "dragLeave",
-  "dragOver",
-  "dragEnd",
-  "drop"
+  'dragStart',
+  'drag',
+  'dragEnter',
+  'dragLeave',
+  'dragOver',
+  'dragEnd',
+  'drop',
 ];
 
 /**
@@ -154,8 +154,8 @@ const LIFECYCLE_HOOKS = [
  * @returns {Any}
  */
 function get(obj, path) {
-  return path.split(".").reduce(function(currentObject, pathSegment) {
-    return typeof currentObject == "undefined" || currentObject === null
+  return path.split('.').reduce(function(currentObject, pathSegment) {
+    return typeof currentObject == 'undefined' || currentObject === null
       ? currentObject
       : currentObject[pathSegment];
   }, obj);
@@ -183,7 +183,7 @@ function getFirstDeclaration(j, root) {
  * @returns {String}
  */
 function getPropName(prop) {
-  return get(prop, "key.name");
+  return get(prop, 'key.name');
 }
 
 /**
@@ -193,7 +193,7 @@ function getPropName(prop) {
  * @returns {String}
  */
 function getPropType(prop) {
-  return get(prop, "value.type");
+  return get(prop, 'value.type');
 }
 
 /**
@@ -203,10 +203,7 @@ function getPropType(prop) {
  * @returns {String}
  */
 function getPropCalleeName(prop) {
-  return (
-    get(prop, "value.callee.name") ||
-    get(prop, "value.callee.object.callee.name")
-  );
+  return get(prop, 'value.callee.name') || get(prop, 'value.callee.object.callee.name');
 }
 
 /**
@@ -220,8 +217,7 @@ function shouldSetValue(prop) {
     return true;
   }
   return prop.decoratorNames.every(
-    decoratorName =>
-      decoratorName === "className" || decoratorName === "attribute"
+    decoratorName => decoratorName === 'className' || decoratorName === 'attribute'
   );
 }
 
@@ -232,7 +228,7 @@ function shouldSetValue(prop) {
  * @returns {String}
  */
 function capitalizeFirstLetter(name) {
-  return name ? name.charAt(0).toUpperCase() + name.slice(1) : "";
+  return name ? name.charAt(0).toUpperCase() + name.slice(1) : '';
 }
 
 /**
@@ -241,7 +237,7 @@ function capitalizeFirstLetter(name) {
  * @param {String} word
  * @returns {Boolean}
  */
-function startsWithUpperCaseLetter(word = "") {
+function startsWithUpperCaseLetter(word = '') {
   return !!word && word.charAt(0) !== word.charAt(0).toLowerCase();
 }
 
@@ -251,9 +247,7 @@ function startsWithUpperCaseLetter(word = "") {
  * @returns boolean
  */
 function isClassDecoratorProp(propName) {
-  return (
-    propName === "tagName" || propName === "classNames" || propName === "layout"
-  );
+  return propName === 'tagName' || propName === 'classNames' || propName === 'layout';
 }
 
 /**
@@ -263,8 +257,8 @@ function isClassDecoratorProp(propName) {
  */
 function getModifier(calleeObject) {
   return {
-    prop: get(calleeObject, "callee.property"),
-    args: get(calleeObject, "arguments")
+    prop: get(calleeObject, 'callee.property'),
+    args: get(calleeObject, 'arguments'),
   };
 }
 
@@ -286,5 +280,5 @@ module.exports = {
   LIFECYCLE_HOOKS,
   METHOD_DECORATORS,
   shouldSetValue,
-  startsWithUpperCaseLetter
+  startsWithUpperCaseLetter,
 };

--- a/transforms/helpers/validation-helper.js
+++ b/transforms/helpers/validation-helper.js
@@ -1,20 +1,20 @@
-const minimatch = require("minimatch");
-const { LIFECYCLE_HOOKS, get, getPropName } = require("./util");
+const minimatch = require('minimatch');
+const { LIFECYCLE_HOOKS, get, getPropName } = require('./util');
 
-const UNSUPPORTED_PROP_NAMES = ["actions", "layout"];
+const UNSUPPORTED_PROP_NAMES = ['actions', 'layout'];
 
 const TYPE_PATTERNS = {
-  service: "**/services/**/*.js",
-  services: "**/services/**/*.js",
-  controller: "**/controllers/**/*.js",
-  controllers: "**/controllers/**/*.js",
-  component: "**/components/**/*.js",
-  components: "**/components/**/*.js",
-  route: "**/routes/**/*.js",
-  routes: "**/routes/**/*.js"
+  service: '**/services/**/*.js',
+  services: '**/services/**/*.js',
+  controller: '**/controllers/**/*.js',
+  controllers: '**/controllers/**/*.js',
+  component: '**/components/**/*.js',
+  components: '**/components/**/*.js',
+  route: '**/routes/**/*.js',
+  routes: '**/routes/**/*.js',
 };
 
-const TEST_FILE_PATTERN = "**/*-test.js";
+const TEST_FILE_PATTERN = '**/*-test.js';
 
 /**
  * Returns true if the specified file is a test file
@@ -56,13 +56,13 @@ function hasValidProps(
   const unsupportedPropNames = decorators ? [] : UNSUPPORTED_PROP_NAMES;
 
   return instanceProps.reduce((errors, instanceProp) => {
-    if (!classFields && instanceProp.type === "Literal") {
+    if (!classFields && instanceProp.type === 'Literal') {
       errors.push(`[${instanceProp.name}]: Need option '--class-fields=true'`);
     }
 
     if (
-      instanceProp.type === "ObjectExpression" &&
-      !["actions", "queryParams"].includes(instanceProp.name)
+      instanceProp.type === 'ObjectExpression' &&
+      !['actions', 'queryParams'].includes(instanceProp.name)
     ) {
       errors.push(
         `[${instanceProp.name}]: Transform not supported - value is of type object. For more details: eslint-plugin-ember/avoid-leaking-state-in-ember-objects`
@@ -75,8 +75,7 @@ function hasValidProps(
     }
 
     if (
-      (!decorators &&
-        (instanceProp.hasDecorators || instanceProp.isClassDecorator)) ||
+      (!decorators && (instanceProp.hasDecorators || instanceProp.isClassDecorator)) ||
       unsupportedPropNames.includes(instanceProp.name) ||
       (instanceProp.isCallExpression && !instanceProp.hasDecorators)
     ) {
@@ -108,7 +107,7 @@ function hasValidProps(
  * @param {EOProp} actionsProp
  */
 function getLifecycleHookErrors(actionsProp) {
-  const actionProps = get(actionsProp, "value.properties");
+  const actionProps = get(actionsProp, 'value.properties');
   return actionProps.reduce((errors, actionProp) => {
     const actionName = getPropName(actionProp);
     if (actionName && LIFECYCLE_HOOKS.includes(actionName)) {
@@ -128,7 +127,7 @@ function getLifecycleHookErrors(actionsProp) {
  * @returns {Boolean}
  */
 function isExtendsMixin(j, eoCallExpression) {
-  return j(eoCallExpression).get("arguments").value.length > 1;
+  return j(eoCallExpression).get('arguments').value.length > 1;
 }
 
 /**
@@ -138,7 +137,7 @@ function isExtendsMixin(j, eoCallExpression) {
  * @param {EOProp} actionsProp
  */
 function getInfiniteLoopErrors(j, actionsProp) {
-  const actionProps = get(actionsProp, "value.properties");
+  const actionProps = get(actionsProp, 'value.properties');
   return actionProps.reduce((errors, actionProp) => {
     const actionName = getPropName(actionProp);
     if (actionName) {
@@ -147,15 +146,15 @@ function getInfiniteLoopErrors(j, actionsProp) {
       // Occurences of this.actionName()
       const actionCalls = functExpr.find(j.CallExpression, {
         callee: {
-          type: "MemberExpression",
+          type: 'MemberExpression',
           object: {
-            type: "ThisExpression"
+            type: 'ThisExpression',
           },
           property: {
-            type: "Identifier",
-            name: actionName
-          }
-        }
+            type: 'Identifier',
+            name: actionName,
+          },
+        },
       });
 
       // Occurences of this.get('actionName')() or get(this, 'actionName')()


### PR DESCRIPTION
It's been getting pretty complicated now that we have actual Ember apps checked in as acceptance tests, so I wanted to change our `prettierrc.js` to match their defaults and keep things consistent. It also turns out that the default is not detected/applied universally in a file. This means that currently, any new imports or values we add are being added with double quotes, even though most Ember projects use single quotes by default. This PR also switches the default of the codemod, with the option for users to switch it back.