### PR TITLE
Fix self-links to issues and documentation

### DIFF
--- a/transforms/ember-object/README.md
+++ b/transforms/ember-object/README.md
@@ -722,7 +722,7 @@ const Foo7 = EmberObject.extend({
 /*
 Expect error:
   ValidationError: Validation errors for class 'Foo7':
-    [actions]: Transform not supported - [click]: action name matches one of the lifecycle hooks. Rename and try again. See https://github.com/scalvert/ember-native-class-codemod/issues/34 for more details
+    [actions]: Transform not supported - [click]: action name matches one of the lifecycle hooks. Rename and try again. See https://github.com/ember-codemods/ember-native-class-codemod/issues/34 for more details
 */
 
 // Do not transform as action name matches lifecycle hook
@@ -1012,7 +1012,7 @@ class Foo1 extends EmberObject {
     // class's actions to be safe. This should be refactored to call a normal method
     // on the parent class. If the parent class has not been converted to native
     // classes, it may need to be refactored as well. See
-    // https://github.com/scalvert/ember-native-class-codemod/blob/master/README.md
+    // https://github.com/ember-codemods/ember-native-class-codemod/blob/master/README.md
     // for more details.
     super.actions.baz.call(this, ...arguments);
   }
@@ -2071,7 +2071,7 @@ export default class _Runtime extends Runtime.extend(MyMixin) {
     // class's actions to be safe. This should be refactored to call a normal method
     // on the parent class. If the parent class has not been converted to native
     // classes, it may need to be refactored as well. See
-    // https://github.com/scalvert/ember-native-class-codemod/blob/master/README.md
+    // https://github.com/ember-codemods/ember-native-class-codemod/blob/master/README.md
     // for more details.
     super.actions.overriddenActionMethod.call(this, ...arguments) && this.boolProp;
   }

--- a/transforms/ember-object/__testfixtures__/decorators-invalid-7.output.js
+++ b/transforms/ember-object/__testfixtures__/decorators-invalid-7.output.js
@@ -1,7 +1,7 @@
 /*
 Expect error:
   ValidationError: Validation errors for class 'Foo7':
-    [actions]: Transform not supported - [click]: action name matches one of the lifecycle hooks. Rename and try again. See https://github.com/scalvert/ember-native-class-codemod/issues/34 for more details
+    [actions]: Transform not supported - [click]: action name matches one of the lifecycle hooks. Rename and try again. See https://github.com/ember-codemods/ember-native-class-codemod/issues/34 for more details
 */
 
 // Do not transform as action name matches lifecycle hook

--- a/transforms/ember-object/__testfixtures__/decorators.output.js
+++ b/transforms/ember-object/__testfixtures__/decorators.output.js
@@ -83,7 +83,7 @@ class Foo1 extends EmberObject {
     // class's actions to be safe. This should be refactored to call a normal method
     // on the parent class. If the parent class has not been converted to native
     // classes, it may need to be refactored as well. See
-    // https://github.com/scalvert/ember-native-class-codemod/blob/master/README.md
+    // https://github.com/ember-codemods/ember-native-class-codemod/blob/master/README.md
     // for more details.
     super.actions.baz.call(this, ...arguments);
   }

--- a/transforms/ember-object/__testfixtures__/runtime.output.js
+++ b/transforms/ember-object/__testfixtures__/runtime.output.js
@@ -89,7 +89,7 @@ export default class _Runtime extends Runtime.extend(MyMixin) {
     // class's actions to be safe. This should be refactored to call a normal method
     // on the parent class. If the parent class has not been converted to native
     // classes, it may need to be refactored as well. See
-    // https://github.com/scalvert/ember-native-class-codemod/blob/master/README.md
+    // https://github.com/ember-codemods/ember-native-class-codemod/blob/master/README.md
     // for more details.
     super.actions.overriddenActionMethod.call(this, ...arguments) && this.boolProp;
   }

--- a/transforms/helpers/eo-prop/private/actions/index.ts
+++ b/transforms/helpers/eo-prop/private/actions/index.ts
@@ -88,7 +88,7 @@ export default class EOActionsProp extends AbstractEOProp<
   /**
    * Iterate over actions and verify that the action name does not match the lifecycle hooks
    * The transformation is not supported if an action has the same name as lifecycle hook
-   * Reference: https://github.com/scalvert/ember-native-class-codemod/issues/34
+   * Reference: https://github.com/ember-codemods/ember-native-class-codemod/issues/34
    */
   private get lifecycleHookErrors(): string[] {
     const { actions } = this;
@@ -99,7 +99,7 @@ export default class EOActionsProp extends AbstractEOProp<
         errors.push(
           this.makeActionError(
             name,
-            'action name matches one of the lifecycle hooks. Rename and try again. See https://github.com/scalvert/ember-native-class-codemod/issues/34 for more details'
+            'action name matches one of the lifecycle hooks. Rename and try again. See https://github.com/ember-codemods/ember-native-class-codemod/issues/34 for more details'
           )
         );
       }

--- a/transforms/helpers/eo-prop/private/actions/method.ts
+++ b/transforms/helpers/eo-prop/private/actions/method.ts
@@ -40,7 +40,7 @@ import type { Action } from './index';
  *     // class's actions to be safe. This should be refactored to call a normal method
  *     // on the parent class. If the parent class has not been converted to native
  *     // classes, it may need to be refactored as well. See
- *     // https://github.com/scalvert/ember-native-class-codemod/blob/master/README.md
+ *     // https://github.com/ember-codemods/ember-native-class-codemod/blob/master/README.md
  *     // for more details.
  *     super.actions.baz.call(this, ...arguments);
  *   }

--- a/transforms/helpers/transform-helper.ts
+++ b/transforms/helpers/transform-helper.ts
@@ -70,7 +70,7 @@ function replaceSuperExpressions(
  * // class's actions to be safe. This should be refactored to call a normal method
  * // on the parent class. If the parent class has not been converted to native
  * // classes, it may need to be refactored as well. See
- * // https://github.com/scalvert/ember-native-class-codemod/blob/master/README.md
+ * // https://github.com/ember-codemods/ember-native-class-codemod/blob/master/README.md
  * // for more details.
  * super.actions.baz.call(this, ...arguments);
  * ```

--- a/transforms/helpers/util/index.ts
+++ b/transforms/helpers/util/index.ts
@@ -149,7 +149,7 @@ export const ACTION_SUPER_EXPRESSION_COMMENT = [
   " class's actions to be safe. This should be refactored to call a normal method",
   ' on the parent class. If the parent class has not been converted to native',
   ' classes, it may need to be refactored as well. See',
-  ' https://github.com/scalvert/ember-native-class-codemod/blob/master/README.md',
+  ' https://github.com/ember-codemods/ember-native-class-codemod/blob/master/README.md',
   ' for more details.',
 ];
 


### PR DESCRIPTION
I’m running codemods on an old application and encountered a broken link when there were transformation errors:

```
 ERR app/controllers/rides.js Transformation error (Validation errors for class 'RidesController': 		[actions]: Transform not supported - [submit]: action name matches one of the lifecycle hooks. Rename and try again. See https://github.com/scalvert/ember-native-class-codemod/issues/34 for more details)
ValidationError: Validation errors for class 'RidesController':
		[actions]: Transform not supported - [submit]: action name matches one of the lifecycle hooks. Rename and try again. See https://github.com/scalvert/ember-native-class-codemod/issues/34 for more details
    at maybeTransformEmberObjects (/Users/b/.npm/_npx/4e4aff0f1510c9e0/node_modules/ember-native-class-codemod/transforms/helpers/transform.js:16:19)
    at transformer (/Users/b/.npm/_npx/4e4aff0f1510c9e0/node_modules/ember-native-class-codemod/transforms/ember-object/index.js:41:39)
```

I did a find/replace on all references to the old repository slug, since they all have the same problem.

Thanks for the ongoing maintenance of this, I’m glad it’s still around 🎉